### PR TITLE
Fixes visual studio static compile warings about dll interface.

### DIFF
--- a/cmake/xlnt.cmake
+++ b/cmake/xlnt.cmake
@@ -102,6 +102,9 @@ endif()
 
 if(STATIC)
     add_library(xlnt.static STATIC ${HEADERS} ${SOURCES} ${MINIZ} ${PUGIXML})
+    if(MSVC)
+        target_compile_definitions(xlnt.static PRIVATE XLNT_API=)
+    endif()
     install(TARGETS xlnt.static
         LIBRARY DESTINATION ${LIB_DEST_DIR}
         ARCHIVE DESTINATION ${LIB_DEST_DIR}


### PR DESCRIPTION
BTW, I found that `XLNT_EXPORT` defined in `cmake/xlnt.cmake` is not used.
Does `XLNT_EXPORT` meant to do this?