### PR TITLE
Add implement const version of workbook::get_sheet_by_name().

### DIFF
--- a/source/workbook/tests/test_workbook.hpp
+++ b/source/workbook/tests/test_workbook.hpp
@@ -76,6 +76,17 @@ public:
         TS_ASSERT_EQUALS(new_sheet, found_sheet);
     }
     
+    void test_get_sheet_by_name_const()
+    {
+        xlnt::workbook wb;
+        auto new_sheet = wb.create_sheet();
+        std::string title = "my sheet";
+        new_sheet.set_title(title);
+        const xlnt::workbook& wbconst = wb;
+        auto found_sheet = wbconst.get_sheet_by_name(title);
+        TS_ASSERT_EQUALS(new_sheet, found_sheet);
+    }
+
     void test_index_operator() // test_getitem
     {
         xlnt::workbook wb;

--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -93,7 +93,7 @@ workbook::workbook(encoding e) : workbook()
     d_->encoding_ = e;
 }
 
-worksheet workbook::get_sheet_by_name(const std::string &name)
+const worksheet workbook::get_sheet_by_name(const std::string &name) const
 {
     for (auto &impl : d_->worksheets_)
     {
@@ -104,6 +104,11 @@ worksheet workbook::get_sheet_by_name(const std::string &name)
     }
 
     return worksheet();
+}
+
+worksheet workbook::get_sheet_by_name(const std::string &name)
+{
+	return worksheet(static_cast<const workbook*>(this)->get_sheet_by_name(name));
 }
 
 worksheet workbook::get_sheet_by_index(std::size_t index)


### PR DESCRIPTION
Add implement const version of `workbook::get_sheet_by_name()`.
and non const version are based on const version.