### PR TITLE
Refactor index types

### DIFF
--- a/include/xlnt/cell/index_types.hpp
+++ b/include/xlnt/cell/index_types.hpp
@@ -231,27 +231,27 @@ public:
     /// <summary>
     /// Return the result of adding rhs to this column.
     /// </summary>
-    column_t operator+(const column_t &rhs);
+    friend column_t operator+(column_t lhs, const column_t& rhs);
 
     /// <summary>
-    /// Return the result of adding rhs to this column.
+    /// Return the result of subtracing lhs by rhs column.
     /// </summary>
-    column_t operator-(const column_t &rhs);
+    friend column_t operator-(column_t lhs, const column_t& rhs);
 
     /// <summary>
-    /// Return the result of adding rhs to this column.
+    /// Return the result of multiply lhs by rhs column.
     /// </summary>
-    column_t operator*(const column_t &rhs);
+    friend column_t operator*(column_t lhs, const column_t& rhs);
 
     /// <summary>
-    /// Return the result of adding rhs to this column.
+    /// Return the result of divide lhs by rhs column.
     /// </summary>
-    column_t operator/(const column_t &rhs);
+    friend column_t operator/(column_t lhs, const column_t& rhs);
 
     /// <summary>
-    /// Return the result of adding rhs to this column.
+    /// Return the result of mod lhs by rhs column.
     /// </summary>
-    column_t operator%(const column_t &rhs);
+    friend column_t operator%(column_t lhs, const column_t& rhs);
 
     /// <summary>
     /// Add rhs to this column and return a reference to this column.

--- a/source/cell/index_types.cpp
+++ b/source/cell/index_types.cpp
@@ -166,15 +166,15 @@ column_t operator/(column_t lhs, const column_t& rhs) { lhs /= rhs; return lhs; 
 
 column_t operator%(column_t lhs, const column_t& rhs) { lhs %= rhs; return lhs; }
 
-column_t &column_t::operator+=(const column_t &rhs) { return *this = (*this + rhs); }
+column_t &column_t::operator+=(const column_t &rhs) { index += rhs.index; return *this; }
 
-column_t &column_t::operator-=(const column_t &rhs) { return *this = (*this - rhs); }
+column_t &column_t::operator-=(const column_t &rhs) { index -= rhs.index; return *this; }
 
-column_t &column_t::operator*=(const column_t &rhs) { return *this = (*this * rhs); }
+column_t &column_t::operator*=(const column_t &rhs) { index *= rhs.index; return *this; }
 
-column_t &column_t::operator/=(const column_t &rhs) { return *this = (*this / rhs); }
+column_t &column_t::operator/=(const column_t &rhs) { index /= rhs.index; return *this; }
 
-column_t &column_t::operator%=(const column_t &rhs) { return *this = (*this % rhs); }
+column_t &column_t::operator%=(const column_t &rhs) { index %= rhs.index; return *this; }
 
 bool operator>(const column_t::index_t &left, const column_t &right) { return column_t(left) > right; }
 

--- a/source/cell/index_types.cpp
+++ b/source/cell/index_types.cpp
@@ -252,30 +252,15 @@ column_t column_t::operator++(int) { column_t copy(index); ++(*this); return cop
 /// </summary>
 column_t column_t::operator--(int) { column_t copy(index); --(*this); return copy; }
 
-/// <summary>
-/// Return the result of adding rhs to this column.
-/// </summary>
-column_t column_t::operator+(const column_t &rhs) { column_t copy(*this); copy.index += rhs.index; return copy; }
+column_t operator+(column_t lhs, const column_t& rhs) { lhs += rhs; return lhs; }
 
-/// <summary>
-/// Return the result of adding rhs to this column.
-/// </summary>
-column_t column_t::operator-(const column_t &rhs) { column_t copy(*this); copy.index -= rhs.index; return copy; }
+column_t operator-(column_t lhs, const column_t& rhs) { lhs -= rhs; return lhs; }
 
-/// <summary>
-/// Return the result of adding rhs to this column.
-/// </summary>
-column_t column_t::operator*(const column_t &rhs) { column_t copy(*this); copy.index *= rhs.index; return copy; }
+column_t operator*(column_t lhs, const column_t& rhs) { lhs *= rhs; return lhs; }
 
-/// <summary>
-/// Return the result of adding rhs to this column.
-/// </summary>
-column_t column_t::operator/(const column_t &rhs) { column_t copy(*this); copy.index /= rhs.index; return copy; }
+column_t operator/(column_t lhs, const column_t& rhs) { lhs /= rhs; return lhs; }
 
-/// <summary>
-/// Return the result of adding rhs to this column.
-/// </summary>
-column_t column_t::operator%(const column_t &rhs) { column_t copy(*this); copy.index %= rhs.index; return copy; }
+column_t operator%(column_t lhs, const column_t& rhs) { lhs %= rhs; return lhs; }
 
 /// <summary>
 /// Add rhs to this column and return a reference to this column.

--- a/source/cell/index_types.cpp
+++ b/source/cell/index_types.cpp
@@ -92,164 +92,68 @@ std::string column_t::column_string_from_index(column_t::index_t column_index)
 }
 
 
-/// <summary>
-/// Default column_t is the first (left-most) column.
-/// </summary>
 column_t::column_t() : index(1) {}
 
-/// <summary>
-/// Construct a column from a number.
-/// </summary>
 column_t::column_t(index_t column_index) : index(column_index) {}
 
-/// <summary>
-/// Construct a column from a string.
-/// </summary>
 column_t::column_t(const std::string &column_string) : index(column_index_from_string(column_string)) {}
 
-/// <summary>
-/// Construct a column from a string.
-/// </summary>
 column_t::column_t(const char *column_string) : column_t(std::string(column_string)) {}
 
-/// <summary>
-/// Copy constructor
-/// </summary>
 column_t::column_t(const column_t &other) : column_t(other.index) {}
 
-/// <summary>
-/// Move constructor
-/// </summary>
 column_t::column_t(column_t &&other) { swap(*this, other); }
 
-/// <summary>
-/// Return a string representation of this column index.
-/// </summary>
 std::string column_t::column_string() const { return column_string_from_index(index); }
 
-/// <summary>
-/// Set this column to be the same as rhs's and return reference to self.
-/// </summary>
 column_t &column_t::operator=(column_t rhs) { swap(*this, rhs); return *this; }
 
-/// <summary>
-/// Set this column to be equal to rhs and return reference to self.
-/// </summary>
 column_t &column_t::operator=(const std::string &rhs) { return *this = column_t(rhs); }
 
-/// <summary>
-/// Set this column to be equal to rhs and return reference to self.
-/// </summary>
 column_t &column_t::operator=(const char *rhs) { return *this = column_t(rhs); }
 
-/// <summary>
-/// Return true if this column refers to the same column as other.
-/// </summary>
 bool column_t::operator==(const column_t &other) const { return index == other.index; }
 
-/// <summary>
-/// Return true if this column doesn't refer to the same column as other.
-/// </summary>
 bool column_t::operator!=(const column_t &other) const { return !(*this == other); }
 
-/// <summary>
-/// Return true if this column refers to the same column as other.
-/// </summary>
 bool column_t::operator==(int other) const { return *this == column_t(other); }
 
-/// <summary>
-/// Return true if this column refers to the same column as other.
-/// </summary>
 bool column_t::operator==(index_t other) const { return *this == column_t(other); }
 
-/// <summary>
-/// Return true if this column refers to the same column as other.
-/// </summary>
 bool column_t::operator==(const std::string &other) const { return *this == column_t(other); }
 
-/// <summary>
-/// Return true if this column refers to the same column as other.
-/// </summary>
 bool column_t::operator==(const char *other) const { return *this == column_t(other); }
 
-/// <summary>
-/// Return true if this column doesn't refer to the same column as other.
-/// </summary>
 bool column_t::operator!=(int other) const { return !(*this == other); }
 
-/// <summary>
-/// Return true if this column doesn't refer to the same column as other.
-/// </summary>
 bool column_t::operator!=(index_t other) const { return !(*this == other); }
 
-/// <summary>
-/// Return true if this column doesn't refer to the same column as other.
-/// </summary>
 bool column_t::operator!=(const std::string &other) const { return !(*this == other); }
 
-/// <summary>
-/// Return true if this column doesn't refer to the same column as other.
-/// </summary>
 bool column_t::operator!=(const char *other) const { return !(*this == other); }
 
-/// <summary>
-/// Return true if other is to the right of this column.
-/// </summary>
 bool column_t::operator>(const column_t &other) const { return index > other.index; }
 
-/// <summary>
-/// Return true if other is to the right of or equal to this column.
-/// </summary>
 bool column_t::operator>=(const column_t &other) const { return index >= other.index; }
 
-/// <summary>
-/// Return true if other is to the left of this column.
-/// </summary>
 bool column_t::operator<(const column_t &other) const { return index < other.index; }
 
-/// <summary>
-/// Return true if other is to the left of or equal to this column.
-/// </summary>
 bool column_t::operator<=(const column_t &other) const { return index <= other.index; }
 
-/// <summary>
-/// Return true if other is to the right of this column.
-/// </summary>
 bool column_t::operator>(const column_t::index_t &other) const { return index > other; }
 
-/// <summary>
-/// Return true if other is to the right of or equal to this column.
-/// </summary>
 bool column_t::operator>=(const column_t::index_t &other) const { return index >= other; }
 
-/// <summary>
-/// Return true if other is to the left of this column.
-/// </summary>
 bool column_t::operator<(const column_t::index_t &other) const { return index < other; }
 
-/// <summary>
-/// Return true if other is to the left of or equal to this column.
-/// </summary>
 bool column_t::operator<=(const column_t::index_t &other) const { return index <= other; }
 
-/// <summary>
-/// Pre-increment this column, making it point to the column one to the right.
-/// </summary>
 column_t &column_t::operator++() { index++; return *this; }
 
-/// <summary>
-/// Pre-deccrement this column, making it point to the column one to the left.
-/// </summary>
 column_t &column_t::operator--() { index--; return *this; }
 
-/// <summary>
-/// Post-increment this column, making it point to the column one to the right and returning the old column.
-/// </summary>
 column_t column_t::operator++(int) { column_t copy(index); ++(*this); return copy; }
 
-/// <summary>
-/// Post-decrement this column, making it point to the column one to the left and returning the old column.
-/// </summary>
 column_t column_t::operator--(int) { column_t copy(index); --(*this); return copy; }
 
 column_t operator+(column_t lhs, const column_t& rhs) { lhs += rhs; return lhs; }
@@ -262,54 +166,24 @@ column_t operator/(column_t lhs, const column_t& rhs) { lhs /= rhs; return lhs; 
 
 column_t operator%(column_t lhs, const column_t& rhs) { lhs %= rhs; return lhs; }
 
-/// <summary>
-/// Add rhs to this column and return a reference to this column.
-/// </summary>
 column_t &column_t::operator+=(const column_t &rhs) { return *this = (*this + rhs); }
 
-/// <summary>
-/// Subtrac rhs from this column and return a reference to this column.
-/// </summary>
 column_t &column_t::operator-=(const column_t &rhs) { return *this = (*this - rhs); }
 
-/// <summary>
-/// Multiply this column by rhs and return a reference to this column.
-/// </summary>
 column_t &column_t::operator*=(const column_t &rhs) { return *this = (*this * rhs); }
 
-/// <summary>
-/// Divide this column by rhs and return a reference to this column.
-/// </summary>
 column_t &column_t::operator/=(const column_t &rhs) { return *this = (*this / rhs); }
 
-/// <summary>
-/// Mod this column by rhs and return a reference to this column.
-/// </summary>
 column_t &column_t::operator%=(const column_t &rhs) { return *this = (*this % rhs); }
 
-/// <summary>
-/// Return true if other is to the right of this column.
-/// </summary>
 bool operator>(const column_t::index_t &left, const column_t &right) { return column_t(left) > right; }
 
-/// <summary>
-/// Return true if other is to the right of or equal to this column.
-/// </summary>
 bool operator>=(const column_t::index_t &left, const column_t &right) { return column_t(left) >= right; }
 
-/// <summary>
-/// Return true if other is to the left of this column.
-/// </summary>
 bool operator<(const column_t::index_t &left, const column_t &right) { return column_t(left) < right; }
 
-/// <summary>
-/// Return true if other is to the left of or equal to this column.
-/// </summary>
 bool operator<=(const column_t::index_t &left, const column_t &right) { return column_t(left) <= right; }
 
-/// <summary>
-/// Swap the columns that left and right refer to.
-/// </summary>
 void swap(column_t &left, column_t &right)
 {
     using std::swap;


### PR DESCRIPTION
1. Make binary arithmetic operators for column_t non-member and depends on compound assignments ( [1](http://en.cppreference.com/w/cpp/language/operators), [2](http://stackoverflow.com/a/4421719/87021) ).
2. Remove doc comments in index_types.cpp.