### PR TITLE
Fixes type for all iterator::reference.

### DIFF
--- a/include/xlnt/workbook/const_worksheet_iterator.hpp
+++ b/include/xlnt/workbook/const_worksheet_iterator.hpp
@@ -33,7 +33,7 @@ namespace xlnt {
 class workbook;
 class worksheet;
 
-class XLNT_CLASS const_worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, const worksheet, ptrdiff_t, const worksheet*, const worksheet>
+class XLNT_CLASS const_worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, const worksheet, std::ptrdiff_t, const worksheet*, const worksheet>
 {
 public:
     const_worksheet_iterator(const workbook &wb, std::size_t index);

--- a/include/xlnt/workbook/const_worksheet_iterator.hpp
+++ b/include/xlnt/workbook/const_worksheet_iterator.hpp
@@ -33,7 +33,7 @@ namespace xlnt {
 class workbook;
 class worksheet;
 
-class XLNT_CLASS const_worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, const worksheet>
+class XLNT_CLASS const_worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, const worksheet, ptrdiff_t, const worksheet*, const worksheet>
 {
 public:
     const_worksheet_iterator(const workbook &wb, std::size_t index);

--- a/include/xlnt/workbook/worksheet_iterator.hpp
+++ b/include/xlnt/workbook/worksheet_iterator.hpp
@@ -33,7 +33,7 @@ namespace xlnt {
 class workbook;
 class worksheet;
 
-class XLNT_CLASS worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, worksheet>
+class XLNT_CLASS worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, worksheet, ptrdiff_t, worksheet*, worksheet>
 {
 public:
     worksheet_iterator(workbook &wb, std::size_t index);

--- a/include/xlnt/workbook/worksheet_iterator.hpp
+++ b/include/xlnt/workbook/worksheet_iterator.hpp
@@ -33,7 +33,7 @@ namespace xlnt {
 class workbook;
 class worksheet;
 
-class XLNT_CLASS worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, worksheet, ptrdiff_t, worksheet*, worksheet>
+class XLNT_CLASS worksheet_iterator : public std::iterator<std::bidirectional_iterator_tag, worksheet, std::ptrdiff_t, worksheet*, worksheet>
 {
 public:
     worksheet_iterator(workbook &wb, std::size_t index);

--- a/include/xlnt/worksheet/cell_iterator.hpp
+++ b/include/xlnt/worksheet/cell_iterator.hpp
@@ -37,7 +37,7 @@ class cell_reference;
 class range_reference;
 enum class major_order;
 
-class XLNT_CLASS cell_iterator : public std::iterator<std::bidirectional_iterator_tag, cell>
+class XLNT_CLASS cell_iterator : public std::iterator<std::bidirectional_iterator_tag, cell, ptrdiff_t, cell*, cell>
 {
 public:
     cell_iterator(worksheet ws, const cell_reference &start_cell);

--- a/include/xlnt/worksheet/cell_iterator.hpp
+++ b/include/xlnt/worksheet/cell_iterator.hpp
@@ -23,6 +23,7 @@
 // @author: see AUTHORS file
 #pragma once
 
+#include <cstddef> // std::ptrdiff_t
 #include <iterator>
 
 #include <xlnt/xlnt_config.hpp>
@@ -37,7 +38,7 @@ class cell_reference;
 class range_reference;
 enum class major_order;
 
-class XLNT_CLASS cell_iterator : public std::iterator<std::bidirectional_iterator_tag, cell, ptrdiff_t, cell*, cell>
+class XLNT_CLASS cell_iterator : public std::iterator<std::bidirectional_iterator_tag, cell, std::ptrdiff_t, cell*, cell>
 {
 public:
     cell_iterator(worksheet ws, const cell_reference &start_cell);

--- a/include/xlnt/worksheet/const_cell_iterator.hpp
+++ b/include/xlnt/worksheet/const_cell_iterator.hpp
@@ -37,7 +37,7 @@ class cell_reference;
 class range_reference;
 enum class major_order;
 
-class XLNT_CLASS const_cell_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell>
+class XLNT_CLASS const_cell_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell, ptrdiff_t, const cell*, const cell>
 {
 public:
     const_cell_iterator(worksheet ws, const cell_reference &start_cell);

--- a/include/xlnt/worksheet/const_cell_iterator.hpp
+++ b/include/xlnt/worksheet/const_cell_iterator.hpp
@@ -23,6 +23,7 @@
 // @author: see AUTHORS file
 #pragma once
 
+#include <cstddef> // std::ptrdiff_t
 #include <iterator>
 
 #include <xlnt/xlnt_config.hpp>
@@ -37,7 +38,7 @@ class cell_reference;
 class range_reference;
 enum class major_order;
 
-class XLNT_CLASS const_cell_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell, ptrdiff_t, const cell*, const cell>
+class XLNT_CLASS const_cell_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell, std::ptrdiff_t, const cell*, const cell>
 {
 public:
     const_cell_iterator(worksheet ws, const cell_reference &start_cell);

--- a/include/xlnt/worksheet/const_range_iterator.hpp
+++ b/include/xlnt/worksheet/const_range_iterator.hpp
@@ -22,6 +22,8 @@
 // @author: see AUTHORS file
 #pragma once
 
+#include <cstddef> // std::ptrdiff_t
+
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/cell/cell_reference.hpp>
 #include <xlnt/worksheet/major_order.hpp>
@@ -40,7 +42,7 @@ struct worksheet_impl;
 /// A const version of range_iterator which does not allow modification
 /// to the dereferenced cell_vector.
 /// </summary>
-class XLNT_CLASS const_range_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell_vector, ptrdiff_t, const cell_vector*, const cell_vector>
+class XLNT_CLASS const_range_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell_vector, std::ptrdiff_t, const cell_vector*, const cell_vector>
 {
 public:
     const_range_iterator(

--- a/include/xlnt/worksheet/const_range_iterator.hpp
+++ b/include/xlnt/worksheet/const_range_iterator.hpp
@@ -40,7 +40,7 @@ struct worksheet_impl;
 /// A const version of range_iterator which does not allow modification
 /// to the dereferenced cell_vector.
 /// </summary>
-class XLNT_CLASS const_range_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell_vector>
+class XLNT_CLASS const_range_iterator : public std::iterator<std::bidirectional_iterator_tag, const cell_vector, ptrdiff_t, const cell_vector*, const cell_vector>
 {
 public:
     const_range_iterator(

--- a/include/xlnt/worksheet/range_iterator.hpp
+++ b/include/xlnt/worksheet/range_iterator.hpp
@@ -22,6 +22,8 @@
 // @author: see AUTHORS file
 #pragma once
 
+#include <cstddef> // std::ptrdiff_t
+
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/cell/cell_reference.hpp>
 #include <xlnt/worksheet/major_order.hpp>
@@ -40,7 +42,7 @@ struct worksheet_impl;
 /// An iterator used by worksheet and range for traversing
 /// a 2D grid of cells by row/column then across that row/column.
 /// </summary>
-class XLNT_CLASS range_iterator : public std::iterator<std::bidirectional_iterator_tag, cell_vector, ptrdiff_t, cell_vector*, cell_vector>
+class XLNT_CLASS range_iterator : public std::iterator<std::bidirectional_iterator_tag, cell_vector, std::ptrdiff_t, cell_vector*, cell_vector>
 {
 public:
     range_iterator(worksheet &ws, const range_reference &start_cell, major_order order = major_order::row);

--- a/include/xlnt/worksheet/range_iterator.hpp
+++ b/include/xlnt/worksheet/range_iterator.hpp
@@ -40,7 +40,7 @@ struct worksheet_impl;
 /// An iterator used by worksheet and range for traversing
 /// a 2D grid of cells by row/column then across that row/column.
 /// </summary>
-class XLNT_CLASS range_iterator : public std::iterator<std::bidirectional_iterator_tag, cell_vector>
+class XLNT_CLASS range_iterator : public std::iterator<std::bidirectional_iterator_tag, cell_vector, ptrdiff_t, cell_vector*, cell_vector>
 {
 public:
     range_iterator(worksheet &ws, const range_reference &start_cell, major_order order = major_order::row);


### PR DESCRIPTION
1. we have overloaded operator*() for all iterators, returning a value type T (not a reference).
2. we use the std::reverse_iterator, its operator*() returns a reference type, by default the reference type is T&.

follow implement  std::reverse_iterator::operator*() const are taken form VS2015:

```C++
// in class reverse_iterator

 reference operator*() const
  { // return designated value
  _RanIt _Tmp = current;
  return (*--_Tmp);
  }
```

The `_RanIt` is our base non reverse iterators, the type of `(*--_Tmp)` is `T`. and the `reference` is `T&`. This cause

> warning C4172: returning address of local variable or temporary

And it is bug.

This commit specifies explicitly the 5th template argument for all our iterators base class like `std::iterator<tag,T, ptrdiff_t, T*, T>`.
It make the `reference` to be actually `T` (the value type) and fixes the issue.