### PR TITLE
PERF: optimize read_cell

### DIFF
--- a/source/cell/cell_reference.cpp
+++ b/source/cell/cell_reference.cpp
@@ -22,7 +22,7 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
-#include <locale>
+#include <cctype>
 
 #include <xlnt/cell/cell_reference.hpp>
 #include <xlnt/utils/exceptions.hpp>
@@ -122,9 +122,9 @@ std::pair<std::string, row_t> cell_reference::split_reference(
 
     for (auto character : reference_string)
     {
-        char upper = std::toupper(character, std::locale::classic());
+        char upper = std::toupper(character);
 
-        if (std::isalpha(character, std::locale::classic()))
+        if (std::isalpha(character))
         {
             if (column_part)
             {
@@ -155,7 +155,7 @@ std::pair<std::string, row_t> cell_reference::split_reference(
             {
                 column_part = false;
             }
-            else if (!std::isdigit(character, std::locale::classic()))
+            else if (!std::isdigit(character))
             {
                 throw invalid_cell_reference(reference_string);
             }

--- a/source/cell/index_types.cpp
+++ b/source/cell/index_types.cpp
@@ -21,7 +21,7 @@
 //
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
-#include <locale>
+#include <cctype>
 
 #include <xlnt/cell/index_types.hpp>
 #include <xlnt/utils/exceptions.hpp>
@@ -41,12 +41,12 @@ column_t::index_t column_t::column_index_from_string(const std::string &column_s
 
     for (int i = static_cast<int>(column_string.length()) - 1; i >= 0; i--)
     {
-        if (!std::isalpha(column_string[static_cast<std::size_t>(i)], std::locale::classic()))
+        if (!std::isalpha(column_string[static_cast<std::size_t>(i)]))
         {
             throw invalid_column_index();
         }
 
-        auto char_index = std::toupper(column_string[static_cast<std::size_t>(i)], std::locale::classic()) - 'A';
+        auto char_index = std::toupper(column_string[static_cast<std::size_t>(i)]) - 'A';
 
         column_index += static_cast<column_t::index_t>((char_index + 1) * place);
         place *= 26;

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -167,8 +167,7 @@ cell xlsx_consumer::read_cell()
     if (in_element(sheetData_el))
     {
         expect_start_element(row_el, xml::content::complex); // CT_Row
-        // auto row_index = parser().attribute<row_t>("r");
-		auto row_index = static_cast<row_t>(std::stoul(parser().attribute("r")));
+        auto row_index = static_cast<row_t>(std::stoul(parser().attribute("r")));
 
         if (parser().attribute_present("ht"))
         {
@@ -299,7 +298,7 @@ cell xlsx_consumer::read_cell()
 
     if (!in_element(row_el))
     {
-		expect_end_element(row_el);
+        expect_end_element(row_el);
 
         if (!in_element(sheetData_el))
         {


### PR DESCRIPTION
closes #206
closes #203

@tfussell  - I can break this up into smaller pieces if you want, it was easier profiling to keep stacking changes on top of each other.

On my machine (Windows, non SSD), this takes reading the attached file from ~3.2s to ~1.9s.  Below is a link to the bench script I was profiling against
https://gist.github.com/chris-b1/b49e43536938826d14c8340b808ed05f

[floats.xlsx](https://github.com/tfussell/xlnt/files/1253776/floats.xlsx)

After this the profile graph seems pretty flat, bulk of time happening inside the xml parsing stuff.
