### PR TITLE
Parse readingOrder

### DIFF
--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -2115,6 +2115,11 @@ void xlsx_consumer::read_stylesheet()
                         {
                             alignment.horizontal(parser().attribute<xlnt::horizontal_alignment>("horizontal"));
                         }
+
+                        if (parser().attribute_present("readingOrder"))
+                        {
+                            parser().attribute<int>("readingOrder");
+                        }
                     }
                     else if (xf_child_element == qn("spreadsheetml", "protection"))
                     {


### PR DESCRIPTION
Hello

I've been trying to use the xlnt library, however it failed for some of my inputs.
After some digging I've found out that the attribute present in this PR was missing.

I'm well aware that this is not a fix, but it might be usefull for developers to properly fix it.

Why is the default behaviour of missing attributes to raise an exception and fail to load?