### PR TITLE
Fix for issue #228: Worksheet ID is not always unique

### DIFF
--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -700,7 +700,11 @@ worksheet workbook::create_sheet()
         title = "Sheet" + std::to_string(++index);
     }
 
-    auto sheet_id = d_->worksheets_.size() + 1;
+    size_t sheet_id = 1;
+    for (const auto ws : *this)
+    {
+        sheet_id = std::max(sheet_id, ws.id() + 1);
+    }
     std::string sheet_filename = "sheet" + std::to_string(sheet_id) + ".xml";
 
     d_->worksheets_.push_back(detail::worksheet_impl(this, sheet_id, title));
@@ -726,6 +730,7 @@ worksheet workbook::copy_sheet(worksheet to_copy)
     detail::worksheet_impl impl(*to_copy.d_);
     auto new_sheet = create_sheet();
     impl.title_ = new_sheet.title();
+    impl.id_ = new_sheet.id();
     *new_sheet.d_ = impl;
 
     return new_sheet;

--- a/tests/workbook/workbook_test_suite.hpp
+++ b/tests/workbook/workbook_test_suite.hpp
@@ -56,6 +56,7 @@ public:
         register_test(test_memory);
         register_test(test_clear);
         register_test(test_comparison);
+        register_test(test_id_gen);
     }
 
     void test_active_sheet()
@@ -78,6 +79,7 @@ public:
         auto new_sheet = wb.create_sheet();
         new_sheet.cell("A6").value(1.498);
         wb.copy_sheet(new_sheet);
+        xlnt_assert_differs(wb[1].id(), wb[2].id());
         xlnt_assert(wb[1].compare(wb[2], false));
         wb.create_sheet().cell("A6").value(1.497);
         xlnt_assert(!wb[1].compare(wb[3], false));
@@ -326,5 +328,15 @@ public:
         wb.create_style("style1");
         wb.style("style1");
         wb_const.style("style1");
+    }
+
+    void test_id_gen()
+    {
+        xlnt::workbook wb;
+        wb.create_sheet();
+        wb.create_sheet();
+        wb.remove_sheet(wb[1]);
+        wb.create_sheet();
+        xlnt_assert_differs(wb[1].id(), wb[2].id());
     }
 };


### PR DESCRIPTION
- Worksheet ID now generated from the maximum of existing IDs
- Worksheet ID no longer copied from existing sheet
- Added tests