### PR TITLE
fix -Wcast-qual in miniz

### DIFF
--- a/source/detail/serialization/miniz.cpp
+++ b/source/detail/serialization/miniz.cpp
@@ -2095,7 +2095,7 @@ void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage, int w, int 
     for (y = 0; y < h; ++y)
     {
         tdefl_compress_buffer(pComp, &z, 1, TDEFL_NO_FLUSH);
-        tdefl_compress_buffer(pComp, (mz_uint8 *)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH);
+        tdefl_compress_buffer(pComp, (const mz_uint8 *)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH);
     }
     if (tdefl_compress_buffer(pComp, nullptr, 0, TDEFL_FINISH) != TDEFL_STATUS_DONE)
     {


### PR DESCRIPTION
Fixes the following error I was getting when building on my system:
```
source/detail/serialization/miniz.cpp:2098:50: error: cast from 'const void *' to 'unsigned char *' drops const qualifier [-Werror,-Wcast-qual]
        tdefl_compress_buffer(pComp, (mz_uint8 *)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH);
                                                 ^
1 error generated.
```