### PR TITLE
Travis CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - STATIC=ON
         - SAMPLES=OFF
         - BENCHMARKS=OFF
-    # gcc-6, c++11, debug build, dll
+    # gcc-6, c++11, debug build, dynamic linking
     - os: linux
       compiler: gcc
       addons:
@@ -62,6 +62,24 @@ matrix:
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=ON
+        - SAMPLES=ON
+        - BENCHMARKS=ON
+    # clang 4, c++11, release build, dynamic linking, samples + benchmarks compiled
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - CXX_COMPILER=clang++-4.0
+        - C_COMPILER=clang-4.0
+        - BUILD_TYPE=Release
+        - COVERAGE=OFF
+        - STATIC=OFF
         - SAMPLES=ON
         - BENCHMARKS=ON
     # clang 6, c++11, release build, static linking, samples + benchmarks compiled

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - COVERAGE=ON
         - STATIC=ON
         - SAMPLES=OFF
-        - BENCHMARKS=OFF
+
     # gcc-6, c++11, debug build, dynamic linking
     - os: linux
       compiler: gcc
@@ -42,11 +42,11 @@ matrix:
       env:
         - CXX_COMPILER=g++-6
         - C_COMPILER=gcc-6
-        - BUILD_TYPE=Debug
+        - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=OFF
         - SAMPLES=OFF
-        - BENCHMARKS=OFF
+
     # gcc-8, c++11, release build, static linking, samples + benchmarks compiled
     - os: linux
       compiler: gcc
@@ -63,7 +63,7 @@ matrix:
         - COVERAGE=OFF
         - STATIC=ON
         - SAMPLES=ON
-        - BENCHMARKS=ON
+
     # clang 4, c++11, release build, dynamic linking, samples + benchmarks compiled
     - os: linux
       compiler: clang
@@ -80,8 +80,8 @@ matrix:
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=OFF
-        - SAMPLES=ON
-        - BENCHMARKS=ON
+        - SAMPLES=OFF
+
     # clang 6, c++11, release build, static linking, samples + benchmarks compiled
     - os: linux
       compiler: clang
@@ -99,27 +99,32 @@ matrix:
         - COVERAGE=OFF
         - STATIC=ON
         - SAMPLES=ON
-        - BENCHMARKS=ON
         
 before_install:
   - export CC=${C_COMPILER}
   - export CXX=${CXX_COMPILER}
 
 install:
- - |
-   if [[ "${COVERAGE}" == "ON" ]]; then
-     gem install coveralls-lcov; 
-   fi
-   
- - ${CXX} --version
- - cmake --version
+  - |
+    if [[ "${COVERAGE}" == "ON" ]]; then
+      gem install coveralls-lcov; 
+    fi
+    
+  - ${CXX} --version
+  - cmake --version
 
 script:
- - mkdir build
- - cd build
- - cmake -D STATIC=$STATIC -D BENCHMARKS=$BENCHMARKS -D SAMPLES=$SAMPLES -D COVERAGE=$COVERAGE -D CMAKE_BUILD_TYPE=$BUILD_TYPE ..
- - cmake --build . -- -j2
- - ./tests/xlnt.test
+  - |
+    if [[ "${BUILD_TYPE}" == "Release" && "${STATIC}" == "ON" ]];
+      then BENCHMARKS="ON";
+    else BENCHMARKS="OFF";
+    fi
+    
+  - mkdir build
+  - cd build
+  - cmake -D STATIC=$STATIC -D BENCHMARKS=$BENCHMARKS -D SAMPLES=$SAMPLES -D COVERAGE=$COVERAGE -D CMAKE_BUILD_TYPE=$BUILD_TYPE ..
+  - cmake --build . -- -j2
+  - ./tests/xlnt.test
 
 after_success:
  - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
 # set up build matrix
 matrix:
   include:
+    # ============= CODE COVERAGE ===============
     # gcc-6, c++11, debug build, static linking, code coverage enabled
     - os: linux
       compiler: gcc
@@ -29,7 +30,8 @@ matrix:
         - COVERAGE=ON
         - STATIC=ON
         - SAMPLES=OFF
-
+    
+    # ============= GCC ==================
     # gcc-6, c++11, debug build, dynamic linking
     - os: linux
       compiler: gcc
@@ -46,7 +48,24 @@ matrix:
         - COVERAGE=OFF
         - STATIC=OFF
         - SAMPLES=OFF
-
+        
+    # gcc-8, c++11, release build, static linking, samples + benchmarks compiled
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - CXX_COMPILER=g++-7
+        - C_COMPILER=gcc-7
+        - BUILD_TYPE=Release
+        - COVERAGE=OFF
+        - STATIC=ON
+        - SAMPLES=ON
+        
     # gcc-8, c++11, release build, static linking, samples + benchmarks compiled
     - os: linux
       compiler: gcc
@@ -64,7 +83,8 @@ matrix:
         - STATIC=ON
         - SAMPLES=ON
 
-    # clang 4, c++11, release build, dynamic linking, samples + benchmarks compiled
+    # =========== CLANG =============
+    # clang 4, c++11, release build, dynamic linking
     - os: linux
       compiler: clang
       addons:
@@ -81,8 +101,24 @@ matrix:
         - COVERAGE=OFF
         - STATIC=OFF
         - SAMPLES=OFF
-
-    # clang 6, c++11, release build, static linking, samples + benchmarks compiled
+    # clang 5, c++11, release build, dynamic linking, samples + benchmarks compiled
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - CXX_COMPILER=clang++-5.0
+        - C_COMPILER=clang-5.0
+        - BUILD_TYPE=Release
+        - COVERAGE=OFF
+        - STATIC=ON
+        - SAMPLES=ON
+    # clang 6, c++11, release build, static linking, samples compiled
     - os: linux
       compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,25 +12,6 @@ notifications:
 # set up build matrix
 matrix:
   include:
-    # ============= CODE COVERAGE ===============
-    # gcc-6, c++11, debug build, static linking, code coverage enabled
-    - os: linux
-      compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-            - lcov
-      env:
-        - CXX_COMPILER=g++-6
-        - C_COMPILER=gcc-6
-        - BUILD_TYPE=Debug
-        - COVERAGE=ON
-        - STATIC=ON
-        - SAMPLES=OFF
-    
     # ============= GCC ==================
     # gcc-6, c++11, debug build, dynamic linking
     - os: linux
@@ -44,12 +25,13 @@ matrix:
       env:
         - CXX_COMPILER=g++-6
         - C_COMPILER=gcc-6
+        - CXX_VER=11
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=OFF
         - SAMPLES=OFF
         
-    # gcc-8, c++11, release build, static linking, samples + benchmarks compiled
+    # gcc-7, c++14, release build, static linking, samples + benchmarks compiled
     - os: linux
       compiler: gcc
       addons:
@@ -61,12 +43,13 @@ matrix:
       env:
         - CXX_COMPILER=g++-7
         - C_COMPILER=gcc-7
+        - CXX_VER=14
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=ON
         - SAMPLES=ON
         
-    # gcc-8, c++11, release build, static linking, samples + benchmarks compiled
+    # gcc-8, c++17, release build, static linking, samples + benchmarks compiled
     - os: linux
       compiler: gcc
       addons:
@@ -78,6 +61,7 @@ matrix:
       env:
         - CXX_COMPILER=g++-8
         - C_COMPILER=gcc-8
+        - CXX_VER=17
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=ON
@@ -97,11 +81,13 @@ matrix:
       env:
         - CXX_COMPILER=clang++-4.0
         - C_COMPILER=clang-4.0
+        - CXX_VER=11
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=OFF
         - SAMPLES=OFF
-    # clang 5, c++11, release build, dynamic linking, samples + benchmarks compiled
+        
+    # clang 5, c++14, release build, dynamic linking, samples + benchmarks compiled
     - os: linux
       compiler: clang
       addons:
@@ -114,11 +100,13 @@ matrix:
       env:
         - CXX_COMPILER=clang++-5.0
         - C_COMPILER=clang-5.0
+        - CXX_VER=14
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=ON
         - SAMPLES=ON
-    # clang 6, c++11, release build, static linking, samples compiled
+        
+    # clang 6, c++17, release build, static linking, samples compiled
     - os: linux
       compiler: clang
       addons:
@@ -131,10 +119,31 @@ matrix:
       env:
         - CXX_COMPILER=clang++-6.0
         - C_COMPILER=clang-6.0
+        - CXX_VER=17
         - BUILD_TYPE=Release
         - COVERAGE=OFF
         - STATIC=ON
         - SAMPLES=ON
+
+    # ============= CODE COVERAGE ===============
+    # gcc-6, c++11, debug build, static linking, code coverage enabled
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - lcov
+      env:
+        - CXX_COMPILER=g++-6
+        - C_COMPILER=gcc-6
+        - CXX_VER=11
+        - BUILD_TYPE=Debug
+        - COVERAGE=ON
+        - STATIC=ON
+        - SAMPLES=OFF
         
 before_install:
   - export CC=${C_COMPILER}
@@ -158,7 +167,7 @@ script:
     
   - mkdir build
   - cd build
-  - cmake -D STATIC=$STATIC -D BENCHMARKS=$BENCHMARKS -D SAMPLES=$SAMPLES -D COVERAGE=$COVERAGE -D CMAKE_BUILD_TYPE=$BUILD_TYPE ..
+  - cmake .. -DXLNT_CXX_LANG=${CXX_VER} -DSTATIC=$STATIC -DBENCHMARKS=$BENCHMARKS -DSAMPLES=$SAMPLES -DCOVERAGE=$COVERAGE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
   - cmake --build . -- -j2
   - ./tests/xlnt.test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,106 @@
-language: cpp
+# cpp takes longer
+language: minimal
 sudo: false
 dist: trusty
 
+git:
+  depth: false
+
 notifications:
   email: false
-
-env:
- - COVERAGE=ON STATIC=ON SAMPLES=OFF BENCHMARKS=OFF BUILD_TYPE=Debug
- - COVERAGE=OFF STATIC=ON SAMPLES=ON BENCHMARKS=OFF BUILD_TYPE=Debug
- - COVERAGE=OFF STATIC=OFF SAMPLES=ON BENCHMARKS=OFF BUILD_TYPE=Debug
- - COVERAGE=OFF STATIC=ON SAMPLES=ON BENCHMARKS=ON BUILD_TYPE=Release
- - COVERAGE=OFF STATIC=OFF SAMPLES=ON BENCHMARKS=ON BUILD_TYPE=Release
-
-addons:
-  apt:
-    sources:
-     - ubuntu-toolchain-r-test
-    packages:
-     - g++-6 lcov
+  
+# set up build matrix
+matrix:
+  include:
+    # gcc-6, c++11, debug build, static linking, code coverage enabled
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - lcov
+      env:
+        - CXX_COMPILER=g++-6
+        - C_COMPILER=gcc-6
+        - BUILD_TYPE=Debug
+        - COVERAGE=ON
+        - STATIC=ON
+        - SAMPLES=OFF
+        - BENCHMARKS=OFF
+    # gcc-6, c++11, debug build, dll
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - CXX_COMPILER=g++-6
+        - C_COMPILER=gcc-6
+        - BUILD_TYPE=Debug
+        - COVERAGE=OFF
+        - STATIC=OFF
+        - SAMPLES=OFF
+        - BENCHMARKS=OFF
+    # gcc-8, c++11, release build, static linking, samples + benchmarks compiled
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - CXX_COMPILER=g++-8
+        - C_COMPILER=gcc-8
+        - BUILD_TYPE=Release
+        - COVERAGE=OFF
+        - STATIC=ON
+        - SAMPLES=ON
+        - BENCHMARKS=ON
+    # clang 6, c++11, release build, static linking, samples + benchmarks compiled
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+      env:
+        - CXX_COMPILER=clang++-6.0
+        - C_COMPILER=clang-6.0
+        - BUILD_TYPE=Release
+        - COVERAGE=OFF
+        - STATIC=ON
+        - SAMPLES=ON
+        - BENCHMARKS=ON
+        
+before_install:
+  - export CC=${C_COMPILER}
+  - export CXX=${CXX_COMPILER}
 
 install:
- - export CC=gcc-6
- - export CXX=g++-6
- - gem install coveralls-lcov
+ - |
+   if [[ "${COVERAGE}" == "ON" ]]; then
+     gem install coveralls-lcov; 
+   fi
+   
+ - ${CXX} --version
+ - cmake --version
 
 script:
  - mkdir build
  - cd build
  - cmake -D STATIC=$STATIC -D BENCHMARKS=$BENCHMARKS -D SAMPLES=$SAMPLES -D COVERAGE=$COVERAGE -D CMAKE_BUILD_TYPE=$BUILD_TYPE ..
- - cmake --build .
+ - cmake --build . -- -j2
  - ./tests/xlnt.test
 
 after_success:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,18 @@ set(COMBINED_PROJECT TRUE)
 # Library type
 option(STATIC "Set to ON to build xlnt as a static library instead of a shared library" OFF)
 
+# c++ language standard to use
+set(XLNT_LANGS 11 14 17)
+set(XLNT_CXX_LANG "14" CACHE STRING "c++ language features to compile with")
+# enumerate allowed values for cmake gui
+set_property(CACHE XLNT_CXX_LANG PROPERTY STRINGS ${XLNT_LANGS})
+# validate value is in XLNT_LANGS
+list(FIND XLNT_LANGS ${XLNT_CXX_LANG} index)
+if(index EQUAL -1)
+    message(FATAL_ERROR "XLNT_CXX_LANG must be one of ${XLNT_LANGS}")
+endif()
+
+
 # Optional components
 option(TESTS "Set to OFF to skip building test executable (in ./tests)" ON)
 option(SAMPLES "Set to ON to build executable code samples (in ./samples)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,14 @@ set(COMBINED_PROJECT TRUE)
 option(STATIC "Set to ON to build xlnt as a static library instead of a shared library" OFF)
 
 # c++ language standard to use
-set(XLNT_LANGS 11 14 17)
+set(XLNT_VALID_LANGS 11 14 17)
 set(XLNT_CXX_LANG "14" CACHE STRING "c++ language features to compile with")
 # enumerate allowed values for cmake gui
-set_property(CACHE XLNT_CXX_LANG PROPERTY STRINGS ${XLNT_LANGS})
-# validate value is in XLNT_LANGS
-list(FIND XLNT_LANGS ${XLNT_CXX_LANG} index)
+set_property(CACHE XLNT_CXX_LANG PROPERTY STRINGS ${XLNT_VALID_LANGS})
+# validate value is in XLNT_VALID_LANGS
+list(FIND XLNT_VALID_LANGS ${XLNT_CXX_LANG} index)
 if(index EQUAL -1)
-    message(FATAL_ERROR "XLNT_CXX_LANG must be one of ${XLNT_LANGS}")
+    message(FATAL_ERROR "XLNT_CXX_LANG must be one of ${XLNT_VALID_LANGS}")
 endif()
 
 

--- a/include/xlnt/worksheet/phonetic_pr.hpp
+++ b/include/xlnt/worksheet/phonetic_pr.hpp
@@ -38,7 +38,7 @@ namespace xlnt {
 class XLNT_API phonetic_pr
 {
 public:
-    static const std::string Serialised_ID;
+    static std::string Serialised_ID();
 
     /// <summary>
     /// possible values for alignment property

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -47,6 +47,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-newline-eof") # no longer an issue with post-c++11 standards which mandate include add a newline if neccesary
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-covered-switch-default") # default is often added to switches for completeness or to cover future alternatives
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-exit-time-destructors") # this is just a warning to notify that the destructor will run during exit
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces") # Wmissing-field-initializers has less false positives
 endif()
 
 if(STATIC_CRT)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -37,12 +37,15 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas") # ignore MSVC and Clang pragmas
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything") # all warnings
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror") # warnings are errors
+  # blacklist warnings that are not relevant
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat") # ignore warnings about C++98 compatibility
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat-pedantic") # ignore pedantic warnings about C++98 compatibility
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-padded") # ignore padding warnings
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-documentation-unknown-command") # ignore unknown commands in Javadoc-style comments
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas") # ignore Windows and GCC pragmas
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-float-equal") # don't warn on uses of == for fp types
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-newline-eof") # no longer an issue with post-c++11 standards which mandate include add a newline if neccesary
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-covered-switch-default") # default is often added to switches for completeness or to cover future alternatives
 endif()
 
 if(STATIC_CRT)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(xlnt VERSION 1.2)
 
+set(CMAKE_CXX_STANDARD ${XLNT_CXX_LANG})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CXX_EXTENSIONS OFF)
 
 # Project metadata
@@ -152,7 +154,7 @@ else()
   target_compile_definitions(xlnt PUBLIC XLNT_STATIC=1)
 endif()
 
-target_compile_features(xlnt PUBLIC cxx_std_${XLNT_CXX_LANG})
+#target_compile_features(xlnt PUBLIC cxx_std_${XLNT_CXX_LANG})
 
 # Includes
 target_include_directories(xlnt PUBLIC ${XLNT_INCLUDE_DIR})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -154,6 +154,7 @@ else()
   target_compile_definitions(xlnt PUBLIC XLNT_STATIC=1)
 endif()
 
+# requires cmake 3.8+
 #target_compile_features(xlnt PUBLIC cxx_std_${XLNT_CXX_LANG})
 
 # Includes

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(xlnt VERSION 1.2)
 
-# Require C99 and C++11 compilers
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CXX_EXTENSIONS OFF)
 
 # Project metadata
 set(PROJECT_VENDOR "Thomas Fussell")
@@ -156,6 +152,8 @@ else()
   target_compile_definitions(xlnt PUBLIC XLNT_STATIC=1)
 endif()
 
+target_compile_features(xlnt PUBLIC cxx_std_${XLNT_CXX_LANG})
+
 # Includes
 target_include_directories(xlnt PUBLIC ${XLNT_INCLUDE_DIR})
 target_include_directories(xlnt PRIVATE ${XLNT_SOURCE_DIR})
@@ -178,23 +176,23 @@ if(MSVC)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/cryptography/aes.cpp
     PROPERTIES
     COMPILE_FLAGS "/wd\"4996\"")
-endif()
-
-# Platform- and file-specific settings, Clang
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/serialization/miniz.cpp
-    PROPERTIES
-    COMPILE_FLAGS "-Wno-undef")
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/serialization/zstream.cpp
-    PROPERTIES
-    COMPILE_FLAGS "-Wno-undef -Wno-shorten-64-to-32")
-endif()
-
-# Platform- and file-specific settings, GCC
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/serialization/miniz.cpp
-    PROPERTIES
-    COMPILE_FLAGS "-Wno-strict-aliasing")
+else()
+  # Platform- and file-specific settings, Clang
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/serialization/miniz.cpp
+	  PROPERTIES
+	  COMPILE_FLAGS "-Wno-undef")
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/serialization/zstream.cpp
+	  PROPERTIES
+      COMPILE_FLAGS "-Wno-undef -Wno-shorten-64-to-32")
+  endif()
+  
+  # Platform- and file-specific settings, GCC
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/detail/serialization/miniz.cpp
+	  PROPERTIES
+	  COMPILE_FLAGS "-Wno-strict-aliasing")
+  endif()
 endif()
 
 # Group files into pseudo-folders in IDEs

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -46,6 +46,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-float-equal") # don't warn on uses of == for fp types
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-newline-eof") # no longer an issue with post-c++11 standards which mandate include add a newline if neccesary
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-covered-switch-default") # default is often added to switches for completeness or to cover future alternatives
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-exit-time-destructors") # this is just a warning to notify that the destructor will run during exit
 endif()
 
 if(STATIC_CRT)

--- a/source/cell/rich_text.cpp
+++ b/source/cell/rich_text.cpp
@@ -26,15 +26,22 @@
 #include <xlnt/cell/rich_text.hpp>
 #include <xlnt/cell/rich_text_run.hpp>
 
+namespace {
+bool has_trailing_whitespace(const std::string &s) 
+{
+    return !s.empty() && (s.front() == ' ' || s.back() == ' ');
+};
+}
+
 namespace xlnt {
 
 rich_text::rich_text(const std::string &plain_text)
-    : rich_text(rich_text_run{plain_text, optional<font>(), false})
+    : rich_text(rich_text_run{plain_text, optional<font>(), has_trailing_whitespace(plain_text)})
 {
 }
 
 rich_text::rich_text(const std::string &plain_text, const class font &text_font)
-    : rich_text(rich_text_run{plain_text, optional<font>(text_font), false})
+    : rich_text(rich_text_run{plain_text, optional<font>(text_font), has_trailing_whitespace(plain_text)})
 {
 }
 

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -816,7 +816,6 @@ void xlsx_producer::write_pivot_table(const relationship & /*rel*/)
 void xlsx_producer::write_shared_string_table(const relationship & /*rel*/)
 {
     static const auto &xmlns = constants::ns("spreadsheetml");
-    static const auto &xmlns_xml = constants::ns("xml");
 
     write_start_element(xmlns, "sst");
     write_namespace(xmlns, "");
@@ -853,18 +852,13 @@ void xlsx_producer::write_shared_string_table(const relationship & /*rel*/)
     write_attribute("count", string_count);
     write_attribute("uniqueCount", source_.shared_strings().size());
 
-    auto has_trailing_whitespace = [](const std::string &s)
-    {
-        return !s.empty() && (s.front() == ' ' || s.back() == ' ');
-    };
-
     for (const auto &string : source_.shared_strings())
     {
         if (string.runs().size() == 1 && !string.runs().at(0).second.is_set())
         {
             write_start_element(xmlns, "si");
             write_start_element(xmlns, "t");
-            write_characters(string.plain_text(),string.runs().front().preserve_space);
+            write_characters(string.plain_text(), string.runs().front().preserve_space);
             write_end_element(xmlns, "t");
             write_end_element(xmlns, "si");
 
@@ -926,7 +920,7 @@ void xlsx_producer::write_shared_string_table(const relationship & /*rel*/)
             }
 
             write_start_element(xmlns, "t");
-            write_characters(run.first, has_trailing_whitespace(run.first));
+            write_characters(run.first, run.preserve_space);
             write_end_element(xmlns, "t");
             write_end_element(xmlns, "r");
         }

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2749,7 +2749,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
 
     if (ws.has_phonetic_properties())
     {
-        write_start_element(xmlns, phonetic_pr::Serialised_ID);
+        write_start_element(xmlns, phonetic_pr::Serialised_ID());
         const auto &ph_props = ws.phonetic_properties();
         write_attribute("fontId", ph_props.font_id());
         if (ph_props.has_type())
@@ -2760,7 +2760,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         {
             write_attribute("alignment", phonetic_pr::alignment_as_string(ph_props.alignment()));
         }
-        write_end_element(xmlns, phonetic_pr::Serialised_ID);
+        write_end_element(xmlns, phonetic_pr::Serialised_ID());
     }
 
     if (ws.has_page_margins())

--- a/source/detail/serialization/zstream.cpp
+++ b/source/detail/serialization/zstream.cpp
@@ -366,7 +366,7 @@ public:
             deflateEnd(&strm);
             if (header)
             {
-                std::ios::streampos final_position = ostream.tellp();
+                auto final_position = ostream.tellp();
                 header->uncompressed_size = uncompressed_size;
                 header->crc = crc;
                 ostream.seekp(header->header_offset);
@@ -457,14 +457,14 @@ ozstream::ozstream(std::ostream &stream)
 ozstream::~ozstream()
 {
     // Write all file headers
-    std::ios::streampos final_position = destination_stream_.tellp();
+    auto final_position = destination_stream_.tellp();
 
     for (const auto &header : file_headers_)
     {
         write_header(header, destination_stream_, true);
     }
 
-    std::ios::streampos central_end = destination_stream_.tellp();
+    auto central_end = destination_stream_.tellp();
 
     // Write end of central
     write_int(destination_stream_, static_cast<std::uint32_t>(0x06054b50)); // end of central
@@ -507,12 +507,12 @@ bool izstream::read_central_header()
     // Find the header
     // NOTE: this assumes the zip file header is the last thing written to file...
     source_stream_.seekg(0, std::ios_base::end);
-    std::ios::streampos end_position = source_stream_.tellg();
+    auto end_position = static_cast<std::size_t>(source_stream_.tellg());
 
     auto max_comment_size = std::uint32_t(0xffff); // max size of header
     auto read_size_before_comment = std::uint32_t(22);
 
-    std::ios::streamoff read_start = max_comment_size + read_size_before_comment;
+    std::uint32_t read_start = max_comment_size + read_size_before_comment;
 
     if (read_start > end_position)
     {

--- a/source/styles/font.cpp
+++ b/source/styles/font.cpp
@@ -27,7 +27,11 @@
 #include <xlnt/styles/font.hpp>
 
 namespace {
-const std::string Default_Name = "Calibri";
+const std::string &Default_Name()
+{
+    static const std::string Default("Calibri");
+    return Default;
+}
 constexpr double Default_Size = 12.0;
 } // namespace
 
@@ -161,13 +165,13 @@ font &font::name(const std::string &name)
     return *this;
 }
 
-const std::string& font::name() const
+const std::string &font::name() const
 {
     if (name_.is_set())
     {
         return name_.get();
     }
-    return Default_Name;
+    return Default_Name();
 }
 
 bool font::has_color() const
@@ -229,7 +233,7 @@ std::size_t font::family() const
     return family_.get();
 }
 
-const std::string& font::scheme() const
+const std::string &font::scheme() const
 {
     return scheme_.get();
 }

--- a/source/worksheet/phonetic_pr.cpp
+++ b/source/worksheet/phonetic_pr.cpp
@@ -25,18 +25,27 @@
 #include <array>
 namespace {
 // Order of elements defined by phonetic_pr::Type enum
-const std::array<std::string, 4> Types{
-    "fullwidthKatakana",
-    "halfwidthKatakana",
-    "Hiragana",
-    "noConversion"};
+const std::array<std::string, 4>& Types()
+{
+    static const std::array<std::string, 4> types{
+        "fullwidthKatakana",
+        "halfwidthKatakana",
+        "Hiragana",
+        "noConversion"
+    };
+    return types;
+}
 
 // Order of elements defined by phonetic_pr::alignment enum
-const std::array<std::string, 4> alignments{
-    "Center",
-    "Distributed",
-    "Left",
-    "NoControl"};
+const std::array<std::string, 4> &Alignments()
+{
+    static const std::array<std::string, 4> alignments{
+        "Center",
+        "Distributed",
+        "Left",
+        "NoControl"};
+    return alignments;
+}
 
 } // namespace
 
@@ -108,14 +117,14 @@ void phonetic_pr::alignment(align align)
 // serialisation
 const std::string &phonetic_pr::type_as_string(phonetic_pr::phonetic_type type)
 {
-    return Types[static_cast<int>(type)];
+    return Types()[static_cast<int>(type)];
 }
 
 phonetic_pr::phonetic_type phonetic_pr::type_from_string(const std::string &str)
 {
-    for (std::size_t i = 0; i < Types.size(); ++i)
+    for (std::size_t i = 0; i < Types().size(); ++i)
     {
-        if (str == Types[i])
+        if (str == Types()[i])
         {
             return static_cast<phonetic_type>(i);
         }
@@ -125,14 +134,14 @@ phonetic_pr::phonetic_type phonetic_pr::type_from_string(const std::string &str)
 
 const std::string &phonetic_pr::alignment_as_string(align type)
 {
-    return alignments[static_cast<int>(type)];
+    return Alignments()[static_cast<int>(type)];
 }
 
 phonetic_pr::align phonetic_pr::alignment_from_string(const std::string &str)
 {
-    for (std::size_t i = 0; i < alignments.size(); ++i)
+    for (std::size_t i = 0; i < Alignments().size(); ++i)
     {
-        if (str == alignments[i])
+        if (str == Alignments()[i])
         {
             return static_cast<align>(i);
         }

--- a/source/worksheet/phonetic_pr.cpp
+++ b/source/worksheet/phonetic_pr.cpp
@@ -25,14 +25,13 @@
 #include <array>
 namespace {
 // Order of elements defined by phonetic_pr::Type enum
-const std::array<std::string, 4>& Types()
+const std::array<std::string, 4> &Types()
 {
     static const std::array<std::string, 4> types{
-        "fullwidthKatakana",
-        "halfwidthKatakana",
-        "Hiragana",
-        "noConversion"
-    };
+        std::string("fullwidthKatakana"),
+        std::string("halfwidthKatakana"),
+        std::string("Hiragana"),
+        std::string("noConversion")};
     return types;
 }
 
@@ -40,10 +39,10 @@ const std::array<std::string, 4>& Types()
 const std::array<std::string, 4> &Alignments()
 {
     static const std::array<std::string, 4> alignments{
-        "Center",
-        "Distributed",
-        "Left",
-        "NoControl"};
+        std::string("Center"),
+        std::string("Distributed"),
+        std::string("Left"),
+        std::string("NoControl")};
     return alignments;
 }
 
@@ -53,7 +52,10 @@ namespace xlnt {
 /// <summary>
 /// out of line initialiser for static const member
 /// </summary>
-const std::string phonetic_pr::Serialised_ID = "phoneticPr";
+std::string phonetic_pr::Serialised_ID()
+{
+    return "phoneticPr";
+}
 
 phonetic_pr::phonetic_pr(font_id_t font)
     : font_id_(font)
@@ -62,7 +64,7 @@ phonetic_pr::phonetic_pr(font_id_t font)
 
 void phonetic_pr::serialise(std::ostream &output_stream) const
 {
-    output_stream << '<' << Serialised_ID << R"( fontID=")" << std::to_string(font_id_) << '"';
+    output_stream << '<' << Serialised_ID() << R"( fontID=")" << std::to_string(font_id_) << '"';
     if (has_type())
     {
         output_stream << R"( type=")" << type_as_string(type_.get()) << '"';
@@ -117,7 +119,7 @@ void phonetic_pr::alignment(align align)
 // serialisation
 const std::string &phonetic_pr::type_as_string(phonetic_pr::phonetic_type type)
 {
-    return Types()[static_cast<int>(type)];
+    return Types()[static_cast<std::size_t>(type)];
 }
 
 phonetic_pr::phonetic_type phonetic_pr::type_from_string(const std::string &str)
@@ -134,7 +136,7 @@ phonetic_pr::phonetic_type phonetic_pr::type_from_string(const std::string &str)
 
 const std::string &phonetic_pr::alignment_as_string(align type)
 {
-    return Alignments()[static_cast<int>(type)];
+    return Alignments()[static_cast<std::size_t>(type)];
 }
 
 phonetic_pr::align phonetic_pr::alignment_from_string(const std::string &str)

--- a/source/worksheet/worksheet.cpp
+++ b/source/worksheet/worksheet.cpp
@@ -98,7 +98,7 @@ void worksheet::create_named_range(const std::string &name, const range_referenc
             throw invalid_parameter(); //("named range name must be outside the range A1-XFD1048576");
         }
     }
-    catch (xlnt::invalid_cell_reference)
+    catch (xlnt::invalid_cell_reference&)
     {
         // name is not a valid reference, that's good
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ target_include_directories(xlnt.test
 
 set(XLNT_TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 target_compile_definitions(xlnt.test PRIVATE XLNT_TEST_DATA_DIR=${XLNT_TEST_DATA_DIR})
+# requires cmake 3.8+
 #target_compile_features(xlnt.test PRIVATE cxx_std_${XLNT_CXX_LANG})
 
 if(MSVC)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(xlnt.test)
 
-# Require C++11 compiler
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CXX_EXTENSIONS OFF)
 
 if(NOT COMBINED_PROJECT)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../source ${CMAKE_CURRENT_BINARY_DIR}/source)
@@ -48,6 +46,7 @@ target_include_directories(xlnt.test
 
 set(XLNT_TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 target_compile_definitions(xlnt.test PRIVATE XLNT_TEST_DATA_DIR=${XLNT_TEST_DATA_DIR})
+target_compile_features(xlnt.test PRIVATE cxx_std_${XLNT_CXX_LANG})
 
 if(MSVC)
   # bigobj because there are so many headers in one source file

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(xlnt.test)
 
+set(CMAKE_CXX_STANDARD ${XLNT_CXX_LANG})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CXX_EXTENSIONS OFF)
 
 if(NOT COMBINED_PROJECT)
@@ -46,7 +48,7 @@ target_include_directories(xlnt.test
 
 set(XLNT_TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 target_compile_definitions(xlnt.test PRIVATE XLNT_TEST_DATA_DIR=${XLNT_TEST_DATA_DIR})
-target_compile_features(xlnt.test PRIVATE cxx_std_${XLNT_CXX_LANG})
+#target_compile_features(xlnt.test PRIVATE cxx_std_${XLNT_CXX_LANG})
 
 if(MSVC)
   # bigobj because there are so many headers in one source file


### PR DESCRIPTION
Resolves #147 by adding CI builds extending compiler coverage to GCC (6-8), as well as Clang (4-6)
Additionally, the C++ language standard is modified as follows

| GCC | Clang | C++ Standard |
| --- | --- | --- |
| 6 | 4 | c++11 |
| 7 | 5 | c++14 |
| 8 | 6 | c++17 |

* build times for each individual job are reduced by 60-90 seconds mostly due to passing -j2 with the build arguments (2 additional jobs do increase total time slightly)
* All warnings and compiler errors generated have either been resolved or suppressed (Additional Clang Weverything suppressions: Wfloat-equal, Wnewline-eof, Wcovered-switch-default, Wexit-time-destructors, and Wmissing-braces). Wfloat-equal should be considered, but the rest are all either irrelevant (eof post c++11, switch default, exit-time-dtors), or covered by a warning with less false positives