### PR TITLE
Don't set comment size on explicit overload

### DIFF
--- a/include/xlnt/cell/comment.hpp
+++ b/include/xlnt/cell/comment.hpp
@@ -155,12 +155,12 @@ private:
     /// <summary>
     /// Width of the comment box.
     /// </summary>
-    int width_ = 0;
+    int width_ = 200;
 
     /// <summary>
     /// Height of the comment box.
     /// </summary>
-    int height_ = 0;
+    int height_ = 100;
 };
 
 } // namespace xlnt

--- a/source/cell/cell.cpp
+++ b/source/cell/cell.cpp
@@ -964,16 +964,12 @@ class comment cell::comment()
 
 void cell::comment(const std::string &text, const std::string &author)
 {
-    xlnt::comment tmp_comment(text, author);
-    tmp_comment.size(200, 100);
-    comment(tmp_comment);
+    comment(xlnt::comment(text, author));
 }
 
 void cell::comment(const std::string &text, const class font &comment_font, const std::string &author)
 {
-    xlnt::comment tmp_comment(xlnt::rich_text(text, comment_font), author);
-    tmp_comment.size(200, 100);
-    comment(tmp_comment);
+    comment(xlnt::comment(xlnt::rich_text(text, comment_font), author));
 }
 
 void cell::comment(const class comment &new_comment)

--- a/source/cell/cell.cpp
+++ b/source/cell/cell.cpp
@@ -964,13 +964,16 @@ class comment cell::comment()
 
 void cell::comment(const std::string &text, const std::string &author)
 {
-    comment(xlnt::comment(text, author));
+    xlnt::comment tmp_comment(text, author);
+    tmp_comment.size(200, 100);
+    comment(tmp_comment);
 }
 
 void cell::comment(const std::string &text, const class font &comment_font, const std::string &author)
 {
-    xlnt::rich_text rich_comment_text(text, comment_font);
-    comment(xlnt::comment(rich_comment_text, author));
+    xlnt::comment tmp_comment(xlnt::rich_text(text, comment_font), author);
+    tmp_comment.size(200, 100);
+    comment(tmp_comment);
 }
 
 void cell::comment(const class comment &new_comment)
@@ -991,7 +994,6 @@ void cell::comment(const class comment &new_comment)
     cell_position.second += 5;
 
     d_->comment_.get()->position(cell_position.first, cell_position.second);
-    d_->comment_.get()->size(200, 100);
 
     worksheet().register_comments_in_manifest();
 }

--- a/source/cell/comment.cpp
+++ b/source/cell/comment.cpp
@@ -105,7 +105,11 @@ int comment::height() const
 
 bool comment::operator==(const comment &other) const
 {
-    return text_ == other.text_ && author_ == other.author_;
+    // not comparing top/left as this is set on a per cell basis
+    return text_ == other.text_ 
+        && author_ == other.author_
+        && width_ == other.width_
+        && height_ == other.height_;
 }
 
 bool comment::operator!=(const comment &other) const

--- a/tests/cell/cell_test_suite.cpp
+++ b/tests/cell/cell_test_suite.cpp
@@ -774,6 +774,11 @@ private:
         cell.clear_comment();
         xlnt_assert(!cell.has_comment());
         xlnt_assert_throws(cell.comment(), xlnt::exception);
+
+        xlnt::comment comment_with_size("test comment", "author");
+        comment_with_size.size(1000, 30);
+        cell.comment(comment_with_size);
+        xlnt_assert_equals(cell.comment(), comment_with_size);
     }
 
     void test_copy_and_compare()


### PR DESCRIPTION
Resolves #282 

I find it debatable but acceptable for position to be set (and not part of the equality comparison). At the very least, the use of absolute offsets prevents a sensible default value being used (could equality compare relative position? Would that make sense?).