### PR TITLE
Ensure <color tint=...> is correctly serialised as an optional double

### DIFF
--- a/include/xlnt/styles/color.hpp
+++ b/include/xlnt/styles/color.hpp
@@ -28,6 +28,7 @@
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>
+#include <xlnt/utils/optional.hpp>
 
 namespace xlnt {
 
@@ -285,6 +286,11 @@ public:
     theme_color& theme();
 
     /// <summary>
+    /// Returns true if tint is set
+    /// </summary>
+    bool has_tint() const;
+
+    /// <summary>
     /// Returns the tint of this color.
     /// </summary>
     double tint() const;
@@ -333,12 +339,12 @@ private:
     /// <summary>
     /// The tint of this color
     /// </summary>
-    double tint_ = 0.0;
+    optional<double> tint_;
 
     /// <summary>
     /// Whether or not this is an auto color
     /// </summary>
-    bool auto__ = false;
+    bool auto_color = false;
 };
 
 } // namespace xlnt

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -3032,7 +3032,7 @@ xlnt::color xlsx_consumer::read_color()
 
     if (parser().attribute_present("tint"))
     {
-        result.tint(parser().attribute("tint", 0.0));
+        result.tint(parser().attribute<double>("tint"));
     }
 
     return result;

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -3345,7 +3345,6 @@ void xlsx_producer::write_color(const xlnt::color &color)
         write_attribute("auto", write_bool(true));
         return;
     }
-
     switch (color.type())
     {
     case xlnt::color_type::theme:
@@ -3359,6 +3358,10 @@ void xlsx_producer::write_color(const xlnt::color &color)
     case xlnt::color_type::rgb:
         write_attribute("rgb", color.rgb().hex_string());
         break;
+    }
+    if (color.has_tint())
+    {
+        write_attribute("tint", serialize_number_to_string(color.tint()));
     }
 }
 

--- a/source/styles/color.cpp
+++ b/source/styles/color.cpp
@@ -225,12 +225,12 @@ color_type color::type() const
 
 bool color::auto_() const
 {
-    return auto__;
+    return auto_color;
 }
 
 void color::auto_(bool value)
 {
-    auto__ = value;
+    auto_color = value;
 }
 
 const indexed_color& color::indexed() const
@@ -269,6 +269,11 @@ rgb_color &color::rgb()
     return rgb_;
 }
 
+bool color::has_tint() const
+{
+    return tint_.is_set();
+}
+
 void color::tint(double tint)
 {
     tint_ = tint;
@@ -276,7 +281,7 @@ void color::tint(double tint)
 
 double color::tint() const
 {
-    return tint_;
+    return tint_.is_set() ? tint_.get() : 0.0;
 }
 
 void color::assert_type(color_type t) const
@@ -289,7 +294,11 @@ void color::assert_type(color_type t) const
 
 bool color::operator==(const xlnt::color &other) const
 {
-    if (type_ != other.type_ || std::fabs(tint_ - other.tint_) != 0.0 || auto__ != other.auto__)
+    if (type_ != other.type_ || auto_color != other.auto_color)
+    {
+        return false;
+    }
+    if (tint_.is_set() != other.tint_.is_set() || (tint_.is_set() && std::fabs(tint_.get() - other.tint_.get()) != 0.0))
     {
         return false;
     }


### PR DESCRIPTION
Resolves #277 
Make tint explicitly optional (returning a default of 0.0 / no tint if not set) and checking serialisation/deserialisation of all color attributes