### PR TITLE
Iterator default ctors

### DIFF
--- a/include/xlnt/workbook/worksheet_iterator.hpp
+++ b/include/xlnt/workbook/worksheet_iterator.hpp
@@ -54,6 +54,11 @@ public:
     using reference = worksheet; // intentionally value
 
     /// <summary>
+    /// Default Constructs a worksheet iterator
+    /// </summary>
+    worksheet_iterator() = default;
+
+    /// <summary>
     /// Constructs a worksheet iterator from a workbook and sheet index.
     /// </summary>
     worksheet_iterator(workbook &wb, std::size_t index);
@@ -135,12 +140,12 @@ private:
     /// <summary>
     /// The target workbook of this iterator.
     /// </summary>
-    workbook *wb_;
+    workbook *wb_ = nullptr;
 
     /// <summary>
     /// The index of the worksheet in wb_ this iterator is currently pointing to.
     /// </summary>
-    std::size_t index_;
+    std::size_t index_ = 0;
 };
 
 
@@ -158,6 +163,11 @@ public:
     using difference_type = std::ptrdiff_t;
     using pointer = const worksheet *;
     using reference = const worksheet; // intentionally value
+
+    /// <summary>
+    /// Default Constructs a worksheet iterator
+    /// </summary>
+    const_worksheet_iterator() = default;
 
     /// <summary>
     /// Constructs a worksheet iterator from a workbook and sheet index.
@@ -234,12 +244,12 @@ private:
     /// <summary>
     /// The target workbook of this iterator.
     /// </summary>
-    const workbook *wb_;
+    const workbook *wb_ = nullptr;
 
     /// <summary>
     /// The index of the worksheet in wb_ this iterator is currently pointing to.
     /// </summary>
-    std::size_t index_;
+    std::size_t index_ = 0;
 };
 
 } // namespace xlnt

--- a/include/xlnt/worksheet/cell_iterator.hpp
+++ b/include/xlnt/worksheet/cell_iterator.hpp
@@ -30,6 +30,7 @@
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/cell/cell_reference.hpp>
 #include <xlnt/worksheet/range_reference.hpp>
+#include <xlnt/worksheet/major_order.hpp>
 #include <xlnt/worksheet/worksheet.hpp>
 
 namespace xlnt {

--- a/include/xlnt/worksheet/cell_iterator.hpp
+++ b/include/xlnt/worksheet/cell_iterator.hpp
@@ -56,6 +56,11 @@ public:
     using reference = cell; // intentionally value
 
     /// <summary>
+    /// Default constructs a cell_iterator
+    /// </summary>
+    cell_iterator() = default;
+
+    /// <summary>
     /// Constructs a cell_iterator from a worksheet, range, and iteration settings.
     /// </summary>
     cell_iterator(worksheet ws, const cell_reference &start_cell,
@@ -132,6 +137,27 @@ public:
     cell_iterator operator++(int);
 
 private:
+
+    /// <summary>
+    /// If true, cells that don't exist in the worksheet will be skipped during iteration.
+    /// </summary>
+    bool skip_null_ = false;
+
+    /// <summary>
+    /// If true, when on the last column, the cursor will continue to the next row
+    /// (and vice versa when iterating in column-major order) until reaching the
+    /// bottom right corner of the range.
+    /// </summary>
+    bool wrap_ = false;
+
+    /// <summary>
+    /// The order this iterator will move, by column or by row. Note that
+    /// this has the opposite meaning as in a range_iterator because after
+    /// getting a row-major range_iterator, the row-major cell_iterator will
+    /// iterate over a column and vice versa.
+    /// </summary>
+    major_order order_ = major_order::column;
+
     /// <summary>
     /// The worksheet this iterator will return cells from.
     /// </summary>
@@ -146,26 +172,6 @@ private:
     /// The range of cells this iterator is restricted to
     /// </summary>
     range_reference bounds_;
-
-    /// <summary>
-    /// The order this iterator will move, by column or by row. Note that
-    /// this has the opposite meaning as in a range_iterator because after
-    /// getting a row-major range_iterator, the row-major cell_iterator will
-    /// iterate over a column and vice versa.
-    /// </summary>
-    major_order order_;
-
-    /// <summary>
-    /// If true, cells that don't exist in the worksheet will be skipped during iteration.
-    /// </summary>
-    bool skip_null_;
-
-    /// <summary>
-    /// If true, when on the last column, the cursor will continue to the next row
-    /// (and vice versa when iterating in column-major order) until reaching the
-    /// bottom right corner of the range.
-    /// </summary>
-    bool wrap_;
 };
 
 /// <summary>
@@ -182,6 +188,11 @@ public:
     using difference_type = std::ptrdiff_t;
     using pointer = const cell *;
     using reference = const cell; // intentionally value
+
+    /// <summary>
+    /// Default constructs a cell_iterator
+    /// </summary>
+    const_cell_iterator() = default;
 
     /// <summary>
     /// Constructs a cell_iterator from a worksheet, range, and iteration settings.
@@ -255,6 +266,26 @@ public:
 
 private:
     /// <summary>
+    /// If true, cells that don't exist in the worksheet will be skipped during iteration.
+    /// </summary>
+    bool skip_null_ = false;
+
+    /// <summary>
+    /// If true, when on the last column, the cursor will continue to the next row
+    /// (and vice versa when iterating in column-major order) until reaching the
+    /// bottom right corner of the range.
+    /// </summary>
+    bool wrap_ = false;
+
+    /// <summary>
+    /// The order this iterator will move, by column or by row. Note that
+    /// this has the opposite meaning as in a range_iterator because after
+    /// getting a row-major range_iterator, the row-major cell_iterator will
+    /// iterate over a column and vice versa.
+    /// </summary>
+    major_order order_ = major_order::column;
+
+    /// <summary>
     /// The worksheet this iterator will return cells from.
     /// </summary>
     worksheet ws_;
@@ -268,26 +299,6 @@ private:
     /// The range of cells this iterator is restricted to
     /// </summary>
     range_reference bounds_;
-
-    /// <summary>
-    /// The order this iterator will move, by column or by row. Note that
-    /// this has the opposite meaning as in a range_iterator because after
-    /// getting a row-major range_iterator, the row-major cell_iterator will
-    /// iterate over a column and vice versa.
-    /// </summary>
-    major_order order_;
-
-    /// <summary>
-    /// If true, cells that don't exist in the worksheet will be skipped during iteration.
-    /// </summary>
-    bool skip_null_;
-
-    /// <summary>
-    /// If true, when on the last column, the cursor will continue to the next row
-    /// (and vice versa when iterating in column-major order) until reaching the
-    /// bottom right corner of the range.
-    /// </summary>
-    bool wrap_;
 };
 
 } // namespace xlnt

--- a/include/xlnt/worksheet/range_iterator.hpp
+++ b/include/xlnt/worksheet/range_iterator.hpp
@@ -52,6 +52,11 @@ public:
     using reference = cell_vector; // intentionally value
 
     /// <summary>
+    /// Default constructs a range iterator 
+    /// </summary>
+    range_iterator() = default;
+
+    /// <summary>
     /// Constructs a range iterator on a worksheet, cell pointing to the current
     /// row or column, range bounds, an order, and whether or not to skip null column/rows.
     /// </summary>
@@ -125,6 +130,16 @@ public:
 
 private:
     /// <summary>
+    /// If true, empty rows and cells will be skipped when iterating with this iterator
+    /// </summary>
+    bool skip_null_ = false;
+
+    /// <summary>
+    /// Whether rows or columns should be iterated over first
+    /// </summary>
+    major_order order_ = major_order::column;
+
+    /// <summary>
     /// The worksheet
     /// </summary>
     worksheet ws_;
@@ -138,16 +153,6 @@ private:
     /// The bounds of the range
     /// </summary>
     range_reference bounds_;
-
-    /// <summary>
-    /// Whether rows or columns should be iterated over first
-    /// </summary>
-    major_order order_;
-
-    /// <summary>
-    /// If true, empty rows and cells will be skipped when iterating with this iterator
-    /// </summary>
-    bool skip_null_;
 };
 
 /// <summary>
@@ -165,6 +170,11 @@ public:
     using difference_type = std::ptrdiff_t;
     using pointer = const cell_vector *;
     using reference = const cell_vector; // intentionally value
+
+    /// <summary>
+    /// Default constructs a range iterator
+    /// </summary>
+    const_range_iterator() = default;
 
     /// <summary>
     /// Constructs a range iterator on a worksheet, cell pointing to the current
@@ -235,6 +245,16 @@ public:
 
 private:
     /// <summary>
+    /// If true, empty rows and cells will be skipped when iterating with this iterator
+    /// </summary>
+    bool skip_null_ = false;
+
+    /// <summary>
+    /// Determines whether iteration should move through rows or columns first
+    /// </summary>
+    major_order order_ = major_order::column;
+
+    /// <summary>
     /// The implementation of the worksheet this iterator points to
     /// </summary>
     detail::worksheet_impl *ws_;
@@ -248,16 +268,6 @@ private:
     /// The range this iterator starts and ends in
     /// </summary>
     range_reference bounds_;
-
-    /// <summary>
-    /// Determines whether iteration should move through rows or columns first
-    /// </summary>
-    major_order order_;
-
-    /// <summary>
-    /// If true, empty rows and cells will be skipped when iterating with this iterator
-    /// </summary>
-    bool skip_null_;
 };
 
 } // namespace xlnt

--- a/source/worksheet/cell_iterator.cpp
+++ b/source/worksheet/cell_iterator.cpp
@@ -30,12 +30,12 @@ namespace xlnt {
 
 cell_iterator::cell_iterator(worksheet ws, const cell_reference &cursor,
     const range_reference &bounds, major_order order, bool skip_null, bool wrap)
-    : ws_(ws),
-      cursor_(cursor),
-      bounds_(bounds),
+    : skip_null_(skip_null),
+      wrap_(wrap),
       order_(order),
-      skip_null_(skip_null),
-      wrap_(wrap)
+      ws_(ws),
+      cursor_(cursor),
+      bounds_(bounds)
 {
     if (skip_null && !ws.has_cell(cursor_))
     {
@@ -45,12 +45,12 @@ cell_iterator::cell_iterator(worksheet ws, const cell_reference &cursor,
 
 const_cell_iterator::const_cell_iterator(worksheet ws, const cell_reference &cursor,
     const range_reference &bounds, major_order order, bool skip_null, bool wrap)
-    : ws_(ws),
-      cursor_(cursor),
-      bounds_(bounds),
+    : skip_null_(skip_null),
+      wrap_(wrap),
       order_(order),
-      skip_null_(skip_null),
-      wrap_(wrap)
+      ws_(ws),
+      cursor_(cursor),
+      bounds_(bounds)
 {
     if (skip_null && !ws.has_cell(cursor_))
     {

--- a/source/worksheet/range_iterator.cpp
+++ b/source/worksheet/range_iterator.cpp
@@ -40,11 +40,11 @@ const range_iterator::reference range_iterator::operator*() const
 
 range_iterator::range_iterator(worksheet &ws, const cell_reference &cursor,
     const range_reference &bounds, major_order order, bool skip_null)
-    : ws_(ws),
-      cursor_(cursor),
-      bounds_(bounds),
+    : skip_null_(skip_null),
       order_(order),
-      skip_null_(skip_null)
+      ws_(ws),
+      cursor_(cursor),
+      bounds_(bounds)
 {
     if (skip_null_ && (**this).empty())
     {
@@ -156,11 +156,11 @@ range_iterator range_iterator::operator++(int)
 
 const_range_iterator::const_range_iterator(const worksheet &ws, const cell_reference &cursor,
     const range_reference &bounds, major_order order, bool skip_null)
-    : ws_(ws.d_),
-      cursor_(cursor),
-      bounds_(bounds),
+    : skip_null_(skip_null),
       order_(order),
-      skip_null_(skip_null)
+      ws_(ws.d_),
+      cursor_(cursor),
+      bounds_(bounds)
 {
     if (skip_null_ && (**this).empty())
     {

--- a/tests/workbook/workbook_test_suite.cpp
+++ b/tests/workbook/workbook_test_suite.cpp
@@ -257,6 +257,8 @@ public:
         iter = temp--;
         xlnt_assert_equals((*iter).title(), "Sheet2");
         xlnt_assert_equals((*temp).title(), "Sheet1");
+
+        xlnt_assert_equals(xlnt::const_worksheet_iterator{}, xlnt::const_worksheet_iterator{});
     }
 
     void test_get_index()

--- a/tests/workbook/workbook_test_suite.cpp
+++ b/tests/workbook/workbook_test_suite.cpp
@@ -214,6 +214,8 @@ public:
         iter = temp--;
         xlnt_assert_equals((*iter).title(), "Sheet2");
         xlnt_assert_equals((*temp).title(), "Sheet1");
+
+        xlnt_assert_equals(xlnt::worksheet_iterator{}, xlnt::worksheet_iterator{});
     }
 
     void test_const_iter()

--- a/tests/worksheet/worksheet_test_suite.cpp
+++ b/tests/worksheet/worksheet_test_suite.cpp
@@ -27,10 +27,9 @@
 #include <xlnt/cell/hyperlink.hpp>
 #include <xlnt/workbook/workbook.hpp>
 #include <xlnt/worksheet/column_properties.hpp>
-#include <xlnt/worksheet/row_properties.hpp>
-#include <xlnt/worksheet/range.hpp>
-#include <xlnt/worksheet/worksheet.hpp>
 #include <xlnt/worksheet/header_footer.hpp>
+#include <xlnt/worksheet/range.hpp>
+#include <xlnt/worksheet/row_properties.hpp>
 #include <xlnt/worksheet/worksheet.hpp>
 #include <helpers/test_suite.hpp>
 
@@ -1052,6 +1051,9 @@ public:
         const_range_iter++;
         const_range_iter--;
         xlnt_assert_equals(const_range_iter, const_range.begin());
+
+        xlnt_assert_equals(xlnt::cell_iterator{}, xlnt::cell_iterator{});
+        xlnt_assert_equals(xlnt::range_iterator{}, xlnt::range_iterator{});
     }
 
     void test_range_reference()

--- a/tests/worksheet/worksheet_test_suite.cpp
+++ b/tests/worksheet/worksheet_test_suite.cpp
@@ -607,6 +607,9 @@ public:
                 xlnt_assert_equals(cell.value<std::string>(), cell.reference().to_string());
             }
         }
+
+        xlnt_assert_equals(xlnt::const_cell_iterator{}, xlnt::const_cell_iterator{});
+        xlnt_assert_equals(xlnt::const_range_iterator{}, xlnt::const_range_iterator{});
     }
 
     void test_const_reverse_iterators()


### PR DESCRIPTION
Resolves #256 
C++ standard requires Fwd iterators and better to be default constructible. The only defined requirement is that two default constructed iterators compare equal (everything else is defined per container).

This implementation compares false against non-default iterators, and functions other than equality are undefinied