### PR TITLE
Serialisation locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=g++-6
         - C_COMPILER=gcc-6
@@ -40,6 +42,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-7
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=g++-7
         - C_COMPILER=gcc-7
@@ -58,6 +62,8 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-8
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=g++-8
         - C_COMPILER=gcc-8
@@ -78,6 +84,8 @@ matrix:
             - llvm-toolchain-trusty-4.0
           packages:
             - clang-4.0
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=clang++-4.0
         - C_COMPILER=clang-4.0
@@ -97,6 +105,8 @@ matrix:
             - llvm-toolchain-trusty-5.0
           packages:
             - clang-5.0
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=clang++-5.0
         - C_COMPILER=clang-5.0
@@ -116,6 +126,8 @@ matrix:
             - llvm-toolchain-trusty-6.0
           packages:
             - clang-6.0
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=clang++-6.0
         - C_COMPILER=clang-6.0
@@ -136,6 +148,8 @@ matrix:
           packages:
             - g++-6
             - lcov
+            - language-pack-en
+            - language-pack-de
       env:
         - CXX_COMPILER=g++-6
         - C_COMPILER=gcc-6

--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -253,6 +253,20 @@ std::string content_type(xlnt::relationship_type type)
     default_case("application/xml");
 }
 
+struct Serialisation_Locale
+{
+    std::locale current_locale;
+
+    Serialisation_Locale()
+    {
+        std::locale::global(std::locale::classic());
+    }
+    ~Serialisation_Locale()
+    {
+        std::locale::global(current_locale);
+    }
+};
+
 } // namespace
 
 namespace xlnt {
@@ -863,6 +877,7 @@ range workbook::named_range(const std::string &name)
 
 void workbook::load(std::istream &stream)
 {
+    Serialisation_Locale loc;
     clear();
     detail::xlsx_consumer consumer(*this);
     consumer.read(stream);
@@ -930,6 +945,7 @@ void workbook::load(const std::vector<std::uint8_t> &data, const std::string &pa
 
 void workbook::load(std::istream &stream, const std::string &password)
 {
+    Serialisation_Locale loc;
     clear();
     detail::xlsx_consumer consumer(*this);
     consumer.read(stream, password);
@@ -975,12 +991,14 @@ void workbook::save(const path &filename, const std::string &password) const
 
 void workbook::save(std::ostream &stream) const
 {
+    Serialisation_Locale loc;
     detail::xlsx_producer producer(*this);
     producer.write(stream);
 }
 
 void workbook::save(std::ostream &stream, const std::string &password) const
 {
+    Serialisation_Locale loc;
     detail::xlsx_producer producer(*this);
     producer.write(stream, password);
 }

--- a/tests/workbook/serialization_test_suite.cpp
+++ b/tests/workbook/serialization_test_suite.cpp
@@ -616,7 +616,8 @@ public:
         std::locale tmp_locale;
         std::locale reset_locale_to;
         Hold_Locale(const std::string &set_locale_to)
-            : tmp_locale(set_locale_to), reset_locale_to()
+            // .c_str() required for Clang CI which is missing the string overload
+            : tmp_locale(set_locale_to.c_str()), reset_locale_to()
         {
             std::locale::global(tmp_locale);
         }
@@ -632,7 +633,7 @@ public:
 #ifdef _WIN32
         Hold_Locale tmp("de-de");
 #else
-        Hold_Locale tmp("de-DE.utf8");
+        Hold_Locale tmp("de_DE.UTF-8");
 #endif
         xlnt_assert(round_trip_matches_rw(path_helper::test_file("13_custom_heights_widths.xlsx")));
     }


### PR DESCRIPTION
Resolves #326 

From what I can tell, workbooks are always serialised using the "C" locale. If this assumption is incorrect, the PR is incorrect and a fix based upon detection of the locale will be required.

The other issue with this PR is that during (de)serialisation, the locale will have changed in any other thread. I'm not aware of a portable way to set/reset the thread local C++ locale (due to unfamiliarity in this area rather than any exhaustive search/experimentation)