### PR TITLE
Corrected the calculation and formatting of weekdays

### DIFF
--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -1673,13 +1673,13 @@ std::string number_formatter::format_number(const format_code &format, double nu
 
         case template_part::template_type::day_abbreviation:
             {
-                result.append(day_names->at(static_cast<std::size_t>(dt.weekday()) - 1).substr(0, 3));
+                result.append(day_names->at(static_cast<std::size_t>(dt.weekday())).substr(0, 3));
                 break;
             }
 
         case template_part::template_type::day_name:
             {
-                result.append(day_names->at(static_cast<std::size_t>(dt.weekday()) - 1));
+                result.append(day_names->at(static_cast<std::size_t>(dt.weekday())));
                 break;
             }
         }

--- a/source/utils/date.cpp
+++ b/source/utils/date.cpp
@@ -126,18 +126,10 @@ date date::today()
 
 int date::weekday() const
 {
-    auto year_temp = (month == 1 || month == 2) ? year - 1 : year;
-    auto month_temp = month == 1 ? 13 : month == 2 ? 14 : month;
-    auto day_temp = day + 1;
+    std::tm tm {0, 0, 0, day, month - 1, year - 1900};
+    std::time_t time = std::mktime(&tm);
 
-    auto days = day_temp + static_cast<int>(13 * (month_temp + 1) / 5.0) + (year_temp % 100)
-        + static_cast<int>((year_temp % 100) / 4.0);
-    auto gregorian = days + static_cast<int>(year_temp / 400.0) - 2 * year_temp / 100;
-    auto julian = days + 5 - year_temp / 100;
-
-    int weekday = (year_temp > 1582 ? gregorian : julian) % 7;
-
-    return weekday == 0 ? 7 : weekday;
+    return safe_localtime(time).tm_wday;
 }
 
 } // namespace xlnt

--- a/tests/styles/number_format_test_suite.cpp
+++ b/tests/styles/number_format_test_suite.cpp
@@ -37,12 +37,12 @@ public:
     {
         register_test(test_basic);
         register_test(test_simple_format);
+        register_test(test_bad_date_format);
         register_test(test_simple_date);
         register_test(test_short_month);
         register_test(test_month_abbreviation);
         register_test(test_month_name);
         register_test(test_basic);
-        register_test(test_simple_format);
         register_test(test_upper_case_date);
         register_test(test_simple_date);
         register_test(test_short_day);
@@ -155,6 +155,46 @@ public:
         xlnt_assert_equals(formatted, "zero0");
     }
 
+    void test_bad_date_format()
+    {
+        auto date = xlnt::date(2016, 6, 18);
+        auto date_number = date.to_number(xlnt::calendar::windows_1900);
+
+        xlnt::number_format nf;
+
+        nf.format_string("[x]");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("mmmmmm");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("ddddd");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("yyy");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("hhh");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("sss");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("AA");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+
+        nf.format_string("q");
+        xlnt_assert_throws(nf.format(date_number, xlnt::calendar::windows_1900),
+                           std::runtime_error);
+    }
+
     void test_upper_case_date()
     {
         auto date = xlnt::date(2016, 6, 18);
@@ -259,7 +299,7 @@ public:
         nf.format_string("dddd");
         auto formatted = nf.format(date_number, xlnt::calendar::windows_1900);
 
-        xlnt_assert_equals(formatted, "Sunday");
+        xlnt_assert_equals(formatted, "Saturday");
     }
 
     void test_day_abbreviation()
@@ -271,7 +311,7 @@ public:
         nf.format_string("ddd");
         auto formatted = nf.format(date_number, xlnt::calendar::windows_1900);
 
-        xlnt_assert_equals(formatted, "Sun");
+        xlnt_assert_equals(formatted, "Sat");
     }
 
     void test_month_letter()

--- a/tests/utils/datetime_test_suite.cpp
+++ b/tests/utils/datetime_test_suite.cpp
@@ -40,6 +40,7 @@ public:
         register_test(test_early_date);
         register_test(test_mac_calendar);
         register_test(test_operators);
+        register_test(test_weekday);
     }
 
     void test_from_string()
@@ -112,6 +113,13 @@ public:
         xlnt::date d3(2016, 7, 15);
         xlnt_assert_equals(d1, d2);
         xlnt_assert_differs(d1, d3);
+    }
+
+    void test_weekday()
+    {
+        xlnt_assert_equals(xlnt::date(2000, 1, 1).weekday(), 6);
+        xlnt_assert_equals(xlnt::date(2016, 7, 15).weekday(), 5);
+        xlnt_assert_equals(xlnt::date(2018, 10, 29).weekday(), 1);
     }
 };
 static datetime_test_suite x;


### PR DESCRIPTION
Resolves #254 

Some of the unit tests for number/date formatting were wrong and after resolving those I discovered that the actual calculations was not correct. Instead I replaced using ctime which should be pretty reliable.