### PR TITLE
Fix relationship sorting

### DIFF
--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -1617,9 +1617,9 @@ struct rel_id_sorter
     bool operator()(const xlnt::relationship &lhs, const xlnt::relationship &rhs)
     {
         // format is rTd<decimal number 1..n>
-        if (lhs.id().size() < rhs.id().size()) // a number with more digits will be larger
+        if (lhs.id().size() != rhs.id().size()) // a number with more digits will be larger
         {
-            return true;
+            return lhs.id().size() < rhs.id().size();
         }
         return lhs.id() < rhs.id();
     }


### PR DESCRIPTION
The current implementation of `rel_id_sorter` incorrectly returns true whenever `lhs.id()` is longer but starts with a lower digit than `rhs.id()`. For example "rId11 < rId2". This in turn causes std::sort to crash with a confusing segfault (under MinGW 7.3.0).

This is fixed by checking for both shorter and longer id string.

This issue only appears when adding more than about 15-20 worksheets to the workbook.