### PR TITLE
Added CTest support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(xlnt_all)
 
+# CTest setup
+# include (CTest) # Add this for valgrind support; CTest works without it
+enable_testing()
+
 # This indicates to CMakeLists in subdirectories that they are part of a larger project
 set(COMBINED_PROJECT TRUE)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,3 +73,6 @@ if(MSVC AND NOT STATIC)
     $<TARGET_FILE:xlnt>
     $<TARGET_FILE_DIR:xlnt.test>)
 endif()
+
+# Use add_test() for CTest support
+add_test(NAME xlnt_test COMMAND xlnt.test)


### PR DESCRIPTION
I added a few lines to CMakeLists.txt in ./tests and in the project root to support using CTest as a test driver. This change shouldn't impact the code or the existing build process; all tests pass (Linux Mint 19.1, clang version 6.0.0-1ubuntu2, x86_64-pc-linux-gnu)