### PR TITLE
Fix crash when adding more than 7 worksheets as detailed in issue #411.

### DIFF
--- a/source/workbook/workbook.cpp
+++ b/source/workbook/workbook.cpp
@@ -1621,6 +1621,12 @@ struct rel_id_sorter
         {
             return true;
         }
+
+        if (lhs.id().size() > rhs.id().size())
+        {
+            return false;
+        }
+
         return lhs.id() < rhs.id();
     }
 };


### PR DESCRIPTION
This fixes the observed crash.