### PR TITLE
Accelerated worksheet parsing

### DIFF
--- a/benchmarks/spreadsheet-load.cpp
+++ b/benchmarks/spreadsheet-load.cpp
@@ -5,7 +5,7 @@
 namespace {
 using milliseconds_d = std::chrono::duration<double, std::milli>;
 
-void run_test(xlnt::path &const file, int runs = 10)
+void run_test(const xlnt::path &file, int runs = 10)
 {
     std::cout << file.string() << "\n\n";
 

--- a/benchmarks/spreadsheet-load.cpp
+++ b/benchmarks/spreadsheet-load.cpp
@@ -1,0 +1,33 @@
+#include <xlnt/xlnt.hpp>
+#include <chrono>
+#include <helpers/path_helper.hpp>
+
+namespace {
+using milliseconds_d = std::chrono::duration<double, std::milli>;
+
+void run_test(xlnt::path &const file, int runs = 10)
+{
+    std::cout << file.string() << "\n\n";
+
+    xlnt::workbook wb;
+    std::vector<std::chrono::steady_clock::duration> test_timings;
+
+    for (int i = 0; i < runs; ++i)
+    {
+        auto start = std::chrono::steady_clock::now();
+        wb.load(file);
+
+        auto end = std::chrono::steady_clock::now();
+        wb.clear();
+        test_timings.push_back(end - start);
+
+        std::cout << milliseconds_d(test_timings.back()).count() << " ms\n";
+    }
+}
+} // namespace
+
+int main()
+{
+    run_test(path_helper::benchmark_file("large.xlsx"));
+    run_test(path_helper::benchmark_file("very_large.xlsx"));
+}

--- a/include/xlnt/styles/format.hpp
+++ b/include/xlnt/styles/format.hpp
@@ -214,6 +214,7 @@ public:
 private:
     friend struct detail::stylesheet;
     friend class detail::xlsx_producer;
+    friend class detail::xlsx_consumer;
     friend class cell;
 
     /// <summary>

--- a/include/xlnt/utils/numeric.hpp
+++ b/include/xlnt/utils/numeric.hpp
@@ -146,7 +146,7 @@ struct number_converter
         }
         std::string copy(s);
         auto decimal_pt = std::find(copy.begin(), copy.end(), '.');
-        if (decimal_pt != s.end())
+        if (decimal_pt != copy.end())
         {
             *decimal_pt = ',';
         }

--- a/include/xlnt/utils/numeric.hpp
+++ b/include/xlnt/utils/numeric.hpp
@@ -31,6 +31,7 @@
 
 namespace xlnt {
 namespace detail {
+
 /// <summary>
 /// Takes in any number and outputs a string form of that number which will
 /// serialise and deserialise without loss of precision
@@ -84,8 +85,7 @@ constexpr typename std::common_type<NumberL, NumberR>::type min(NumberL lval, Nu
 /// </summary>
 template <typename EpsilonType = float, // the type to extract epsilon from
     typename LNumber, typename RNumber> // parameter types (deduced)
-bool
-float_equals(const LNumber &lhs, const RNumber &rhs,
+bool float_equals(const LNumber &lhs, const RNumber &rhs,
     int epsilon_scale = 20) // scale the "fuzzy" equality. Higher value gives a more tolerant comparison
 {
     // a type that lhs and rhs can agree on
@@ -111,7 +111,7 @@ float_equals(const LNumber &lhs, const RNumber &rhs,
     // additionally, a scale factor is applied.
     common_t scaled_fuzz = epsilon_scale * epsilon * max(max(xlnt::detail::abs<common_t>(lhs),
                                                              xlnt::detail::abs<common_t>(rhs)), // |max| of parameters.
-                                                         common_t{1}); // clamp
+                               common_t{1}); // clamp
     return ((lhs + scaled_fuzz) >= rhs) && ((rhs + scaled_fuzz) >= lhs);
 }
 

--- a/include/xlnt/utils/numeric.hpp
+++ b/include/xlnt/utils/numeric.hpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <type_traits>
 #include <cassert>
+#include <algorithm>
 
 namespace xlnt {
 namespace detail {

--- a/include/xlnt/utils/optional.hpp
+++ b/include/xlnt/utils/optional.hpp
@@ -25,7 +25,7 @@
 
 #include "xlnt/xlnt_config.hpp"
 #include "xlnt/utils/exceptions.hpp"
-#include "../source/detail/numeric_utils.hpp"
+#include "xlnt/utils/numeric.hpp"
 #include <type_traits>
 
 namespace xlnt {

--- a/include/xlnt/worksheet/sheet_format_properties.hpp
+++ b/include/xlnt/worksheet/sheet_format_properties.hpp
@@ -25,7 +25,7 @@
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/utils/optional.hpp>
-#include "../source/detail/numeric_utils.hpp"
+#include <xlnt/utils/numeric.hpp>
 
 namespace xlnt {
 

--- a/source/detail/header_footer/header_footer_code.cpp
+++ b/source/detail/header_footer/header_footer_code.cpp
@@ -22,7 +22,7 @@
 // @author: see AUTHORS file
 
 #include <detail/header_footer/header_footer_code.hpp>
-#include <detail/numeric_utils.hpp>
+//#include <detail/numeric_utils.hpp>
 
 namespace xlnt {
 namespace detail {

--- a/source/detail/implementations/cell_impl.hpp
+++ b/source/detail/implementations/cell_impl.hpp
@@ -33,7 +33,7 @@
 #include <xlnt/utils/optional.hpp>
 #include <detail/implementations/format_impl.hpp>
 #include <detail/implementations/hyperlink_impl.hpp>
-#include "../numeric_utils.hpp"
+//#include "../numeric_utils.hpp"
 
 namespace xlnt {
 namespace detail {

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -744,7 +744,11 @@ struct Worksheet_Parser
         {
             for (auto &attr : parser->attribute_map())
             {
-                if (attr.first.name() == "ph")
+                if (attr.first.name() == "r")
+                {
+                    ref = Cell_Reference(row_arg, attr.second.value);
+                }
+                else if (attr.first.name() == "ph")
                 {
                     is_phonetic = is_true(attr.second.value);
                 }
@@ -759,10 +763,6 @@ struct Worksheet_Parser
                 else if (attr.first.name() == "t")
                 {
                     type = from_string(attr.second.value);
-                }
-                else if (attr.first.name() == "r")
-                {
-                    ref = Cell_Reference(row_arg, attr.second.value);
                 }
             }
             int level = 1; // nesting level

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -491,7 +491,7 @@ cell xlsx_consumer::read_cell()
 
         if (parser().attribute_present("ht"))
         {
-            row_properties.height = parser().attribute<double>("ht");
+            row_properties.height = converter_.stold(parser().attribute("ht"));
         }
 
         if (parser().attribute_present("customHeight"))
@@ -506,7 +506,7 @@ cell xlsx_consumer::read_cell()
 
         if (parser().attribute_present(qn("x14ac", "dyDescent")))
         {
-            row_properties.dy_descent = parser().attribute<double>(qn("x14ac", "dyDescent"));
+            row_properties.dy_descent = converter_.stold(parser().attribute(qn("x14ac", "dyDescent")));
         }
 
         if (parser().attribute_present("spans"))
@@ -873,23 +873,23 @@ std::string xlsx_consumer::read_worksheet_begin(const std::string &rel_id)
             if (parser().attribute_present("baseColWidth"))
             {
                 ws.d_->format_properties_.base_col_width =
-                    parser().attribute<double>("baseColWidth");
+                    converter_.stold(parser().attribute("baseColWidth"));
             }
             if (parser().attribute_present("defaultColWidth"))
             {
                 ws.d_->format_properties_.default_column_width =
-                    parser().attribute<double>("defaultColWidth");
+                    converter_.stold(parser().attribute("defaultColWidth"));
             }
             if (parser().attribute_present("defaultRowHeight"))
             {
                 ws.d_->format_properties_.default_row_height =
-                    parser().attribute<double>("defaultRowHeight");
+                    converter_.stold(parser().attribute("defaultRowHeight"));
             }
 
             if (parser().attribute_present(qn("x14ac", "dyDescent")))
             {
                 ws.d_->format_properties_.dy_descent =
-                    parser().attribute<double>(qn("x14ac", "dyDescent"));
+                    converter_.stold(parser().attribute(qn("x14ac", "dyDescent")));
             }
 
             skip_attributes();
@@ -906,10 +906,10 @@ std::string xlsx_consumer::read_worksheet_begin(const std::string &rel_id)
                 auto max = static_cast<column_t::index_t>(std::stoull(parser().attribute("max")));
 
                 // avoid uninitialised warnings in GCC by using a lambda to make the conditional initialisation
-                optional<double> width = [](xml::parser &p) -> xlnt::optional<double> {
+                optional<double> width = [this](xml::parser &p) -> xlnt::optional<double> {
                     if (p.attribute_present("width"))
                     {
-                        return (p.attribute<double>("width") * 7 - 5) / 7;
+                        return (converter_.stold(p.attribute("width")) * 7 - 5) / 7;
                     }
                     return xlnt::optional<double>();
                 }(parser());
@@ -2322,7 +2322,7 @@ void xlsx_consumer::read_stylesheet()
                     while (in_element(qn("spreadsheetml", "gradientFill")))
                     {
                         expect_start_element(qn("spreadsheetml", "stop"), xml::content::complex);
-                        auto position = parser().attribute<double>("position");
+                        auto position = converter_.stold(parser().attribute("position"));
                         expect_start_element(qn("spreadsheetml", "color"), xml::content::complex);
                         auto color = read_color();
                         expect_end_element(qn("spreadsheetml", "color"));
@@ -2370,7 +2370,7 @@ void xlsx_consumer::read_stylesheet()
 
                     if (font_property_element == qn("spreadsheetml", "sz"))
                     {
-                        new_font.size(parser().attribute<double>("val"));
+                        new_font.size(converter_.stold(parser().attribute("val")));
                     }
                     else if (font_property_element == qn("spreadsheetml", "name"))
                     {
@@ -3174,7 +3174,7 @@ rich_text xlsx_consumer::read_rich_text(const xml::qname &parent)
 
                         if (current_run_property_element == xml::qname(xmlns, "sz"))
                         {
-                            run.second.get().size(parser().attribute<double>("val"));
+                            run.second.get().size(converter_.stold(parser().attribute("val")));
                         }
                         else if (current_run_property_element == xml::qname(xmlns, "rFont"))
                         {
@@ -3312,7 +3312,7 @@ xlnt::color xlsx_consumer::read_color()
 
     if (parser().attribute_present("tint"))
     {
-        result.tint(parser().attribute<double>("tint"));
+        result.tint(converter_.stold(parser().attribute("tint")));
     }
 
     return result;

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -723,6 +723,11 @@ struct Worksheet_Parser
                 --level;
                 break;
             }
+            case xml::parser::characters:
+            {
+                // ignore, whitespace formatting normally
+                break;
+            }
             default:
             {
                 assert(false);
@@ -793,6 +798,11 @@ struct Worksheet_Parser
                 case xml::parser::end_element:
                 {
                     --level;
+                    break;
+                }
+                case xml::parser::characters:
+                {
+					// ignore whitespace formatting
                     break;
                 }
                 default:

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -126,6 +126,8 @@ struct number_converter
     double result;
 };
 
+#endif
+
 using style_id_pair = std::pair<xlnt::detail::style_impl, std::size_t>;
 
 /// <summary>
@@ -728,6 +730,11 @@ struct Worksheet_Parser
                 // ignore, whitespace formatting normally
                 break;
             }
+            case xml::parser::start_namespace_decl:
+            case xml::parser::start_attribute:
+            case xml::parser::end_namespace_decl:
+            case xml::parser::end_attribute:
+            case xml::parser::eof:
             default:
             {
                 assert(false);
@@ -754,11 +761,11 @@ struct Worksheet_Parser
                 }
                 else if (attr.first.name() == "cm")
                 {
-                    cell_metatdata_idx = strtol(attr.second.value.c_str(), nullptr, 10);
+                    cell_metatdata_idx = static_cast<int>(strtol(attr.second.value.c_str(), nullptr, 10));
                 }
                 else if (attr.first.name() == "s")
                 {
-                    style_index = strtol(attr.second.value.c_str(), nullptr, 10);
+                    style_index = static_cast<int>(strtol(attr.second.value.c_str(), nullptr, 10));
                 }
                 else if (attr.first.name() == "t")
                 {
@@ -806,6 +813,11 @@ struct Worksheet_Parser
                     // ignore whitespace formatting
                     break;
                 }
+                case xml::parser::start_namespace_decl:
+                case xml::parser::start_attribute:
+                case xml::parser::end_namespace_decl:
+                case xml::parser::end_attribute:
+                case xml::parser::eof:
                 default:
                 {
                     assert(false);
@@ -941,11 +953,11 @@ struct Worksheet_Parser
             }
             else if (attr.first.name() == "r")
             {
-                props.second = strtol(attr.second.value.c_str(), nullptr, 10);
+                props.second = static_cast<int>(strtol(attr.second.value.c_str(), nullptr, 10));
             }
             else if (attr.first.name() == "ht")
             {
-                props.first.height = strtod(attr.second.value.c_str(), nullptr);
+                props.first.height = strtod_c(attr.second.value.c_str(), nullptr);
             }
             else if (attr.first.name() == "customHeight")
             {
@@ -953,11 +965,11 @@ struct Worksheet_Parser
             }
             else if (attr.first.name() == "s")
             {
-                props.first.style = strtol(attr.second.value.c_str(), nullptr, 10);
+                props.first.style = strtoul(attr.second.value.c_str(), nullptr, 10);
             }
             else if (attr.first.name() == "dyDescent")
             {
-                props.first.dy_descent = strtod(attr.second.value.c_str(), nullptr);
+                props.first.dy_descent = strtod_c(attr.second.value.c_str(), nullptr);
             }
             else if (attr.first.name() == "spans")
             {
@@ -987,7 +999,7 @@ void xlsx_consumer::read_worksheet_sheetdata()
     }
     for (auto &cell : ws_parser.parsed_cells)
     {
-        detail::cell_impl* ws_cell_impl = ws.cell(cell_reference(cell.ref.column, cell.ref.row)).d_;
+        detail::cell_impl *ws_cell_impl = ws.cell(cell_reference(cell.ref.column, cell.ref.row)).d_;
         if (cell.style_index != -1)
         {
             ws_cell_impl->format_ = target_.format(cell.style_index).d_;
@@ -1019,7 +1031,7 @@ void xlsx_consumer::read_worksheet_sheetdata()
             }
             case Worksheet_Parser::Cell::Value_Type::Number:
             {
-                ws_cell_impl->value_numeric_ = strtod(cell.value.c_str(), nullptr);
+                ws_cell_impl->value_numeric_ = strtod_c(cell.value.c_str(), nullptr);
                 ws_cell_impl->type_ = cell::type::number;
                 break;
             }

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -795,7 +795,7 @@ struct Worksheet_Parser
             case xml::parser::eof:
             default:
             {
-                assert(false);
+                throw xlnt::exception("unexcpected XML parsing event");
             }
             }
         }
@@ -878,7 +878,7 @@ struct Worksheet_Parser
                 case xml::parser::eof:
                 default:
                 {
-                    assert(false);
+                    throw xlnt::exception("unexcpected XML parsing event");
                 }
                 }
             }

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -744,7 +744,7 @@ std::string xlsx_consumer::read_worksheet_begin(const std::string &rel_id)
 namespace {
 struct Worksheet_Parser
 {
-    explicit Worksheet_Parser(xml::parser *parser, number_converter& converter)
+    explicit Worksheet_Parser(xml::parser *parser, number_converter &converter)
     {
         int level = 1; // nesting level
         int current_row = -1;
@@ -805,7 +805,7 @@ struct Worksheet_Parser
     // https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-2.8.1
     struct Cell
     {
-        explicit Cell(int row_arg, xml::parser *parser)
+        explicit Cell(row_t row_arg, xml::parser *parser)
         {
             for (auto &attr : parser->attribute_map())
             {
@@ -929,12 +929,12 @@ struct Worksheet_Parser
         class Cell_Reference
         {
         public:
-            explicit Cell_Reference(int row_arg, int column_arg) noexcept
+            explicit Cell_Reference(row_t row_arg, column_t::index_t column_arg) noexcept
                 : row(row_arg), column(column_arg)
             {
             }
 
-            explicit Cell_Reference(int row_arg, const std::string &reference) noexcept
+            explicit Cell_Reference(row_t row_arg, const std::string &reference) noexcept
                 : row(row_arg)
             {
                 // only three characters allowed for the column
@@ -975,11 +975,11 @@ struct Worksheet_Parser
                         column += *iter - 'A' + 1; // 'A' == 1
                     }
                 }
-                row = strtol(iter, nullptr, 10);
+                row = static_cast<row_t>(strtoul(iter, nullptr, 10));
             }
 
-            int row; // [1, 1048576]
-            int column; // ["A", "ZZZ"] -> [1, 26^3] -> [1, 17576]
+            row_t row; // [1, 1048576]
+            column_t::index_t column; // ["A", "ZZZ"] -> [1, 26^3] -> [1, 17576]
         private:
         };
 
@@ -992,7 +992,7 @@ struct Worksheet_Parser
         Value_Type type = Value_Type::Number; // 't'
     };
     // <row> inside <sheetData> element
-    std::pair<row_properties, int> parse_row(const xml::parser::attribute_map_type &attributes, number_converter& converter)
+    std::pair<row_properties, int> parse_row(const xml::parser::attribute_map_type &attributes, number_converter &converter)
     {
         std::pair<row_properties, int> props;
         for (auto &attr : attributes)
@@ -1037,7 +1037,7 @@ struct Worksheet_Parser
         return props;
     }
 
-    std::vector<std::pair<row_properties, int>> parsed_rows;
+    std::vector<std::pair<row_properties, row_t>> parsed_rows;
     std::vector<Cell> parsed_cells;
 };
 } // namespace

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -598,8 +598,6 @@ cell xlsx_consumer::read_cell()
         cell.formula(formula_value_string);
     }
 
-    number_converter converter;
-
     if (has_value)
     {
         if (type == "str")
@@ -614,7 +612,7 @@ cell xlsx_consumer::read_cell()
         }
         else if (type == "s")
         {
-            cell.d_->value_numeric_ = converter.stold(value_string);
+            cell.d_->value_numeric_ = converter_.stold(value_string);
             cell.data_type(cell::type::shared_string);
         }
         else if (type == "b") // boolean
@@ -623,7 +621,7 @@ cell xlsx_consumer::read_cell()
         }
         else if (type == "n") // numeric
         {
-            cell.value(converter.stold(value_string));
+            cell.value(converter_.stold(value_string));
         }
         else if (!value_string.empty() && value_string[0] == '#')
         {
@@ -974,8 +972,7 @@ void xlsx_consumer::read_worksheet_sheetdata()
     {
         return;
     }
-    number_converter converter;
-    Sheet_Data ws_data = parse_sheet_data(parser_, converter);
+    Sheet_Data ws_data = parse_sheet_data(parser_, converter_);
     // NOTE: parse->construct are seperated here and could easily be threaded
     // with a SPSC queue for what is likely to be an easy performance win
     for (auto &row : ws_data.parsed_rows)
@@ -1013,7 +1010,7 @@ void xlsx_consumer::read_worksheet_sheetdata()
             }
             case cell::type::number:
             {
-                ws_cell_impl->value_numeric_ = converter.stold(cell.value);
+                ws_cell_impl->value_numeric_ = converter_.stold(cell.value);
                 break;
             }
             case cell::type::shared_string:
@@ -1213,12 +1210,12 @@ worksheet xlsx_consumer::read_worksheet_end(const std::string &rel_id)
         {
             page_margins margins;
 
-            margins.top(parser().attribute<double>("top"));
-            margins.bottom(parser().attribute<double>("bottom"));
-            margins.left(parser().attribute<double>("left"));
-            margins.right(parser().attribute<double>("right"));
-            margins.header(parser().attribute<double>("header"));
-            margins.footer(parser().attribute<double>("footer"));
+            margins.top(converter_.stold(parser().attribute("top")));
+            margins.bottom(converter_.stold(parser().attribute("bottom")));
+            margins.left(converter_.stold(parser().attribute("left")));
+            margins.right(converter_.stold(parser().attribute("right")));
+            margins.header(converter_.stold(parser().attribute("header")));
+            margins.footer(converter_.stold(parser().attribute("footer")));
 
             ws.page_margins(margins);
         }

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -51,7 +51,7 @@ namespace {
 template <size_t N>
 inline bool string_arr_loop_equal(const std::string &lhs, const char (&rhs)[N])
 {
-    for (int i = 0; i < N - 1; ++i)
+    for (size_t i = 0; i < N - 1; ++i)
     {
         if (lhs[i] != rhs[i])
         {
@@ -115,7 +115,6 @@ bool is_true(const std::string &bool_string)
     return false;
 #endif
 }
-
 
 using style_id_pair = std::pair<xlnt::detail::style_impl, std::size_t>;
 
@@ -1008,6 +1007,7 @@ void xlsx_consumer::read_worksheet_sheetdata()
                 ws_cell_impl->value_numeric_ = is_true(cell.value) ? 1.0 : 0.0;
                 break;
             }
+            case cell::type::empty:
             case cell::type::number:
             {
                 ws_cell_impl->value_numeric_ = converter_.stold(cell.value);

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -34,6 +34,7 @@
 
 #include <detail/external/include_libstudxml.hpp>
 #include <detail/serialization/zstream.hpp>
+#include <xlnt/utils/numeric.hpp>
 
 namespace xlnt {
 
@@ -409,6 +410,7 @@ private:
     detail::cell_impl *current_cell_;
 
     detail::worksheet_impl *current_worksheet_;
+    number_converter converter_;
 };
 
 } // namespace detail

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -33,10 +33,10 @@
 #include <detail/serialization/vector_streambuf.hpp>
 #include <detail/serialization/xlsx_producer.hpp>
 #include <detail/serialization/zstream.hpp>
-#include <detail/numeric_utils.hpp>
 #include <xlnt/cell/cell.hpp>
 #include <xlnt/cell/hyperlink.hpp>
 #include <xlnt/packaging/manifest.hpp>
+#include <xlnt/utils/numeric.hpp>
 #include <xlnt/utils/path.hpp>
 #include <xlnt/utils/scoped_enum_hash.hpp>
 #include <xlnt/workbook/workbook.hpp>

--- a/source/worksheet/page_margins.cpp
+++ b/source/worksheet/page_margins.cpp
@@ -22,7 +22,7 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 #include <xlnt/worksheet/page_margins.hpp>
-#include "detail/numeric_utils.hpp"
+#include <xlnt/utils/numeric.hpp>
 
 namespace xlnt {
 

--- a/source/worksheet/page_setup.cpp
+++ b/source/worksheet/page_setup.cpp
@@ -22,7 +22,7 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 #include <xlnt/worksheet/page_setup.hpp>
-#include "detail/numeric_utils.hpp"
+#include <xlnt/utils/numeric.hpp>
 
 namespace xlnt {
 

--- a/source/worksheet/worksheet.cpp
+++ b/source/worksheet/worksheet.cpp
@@ -46,7 +46,7 @@
 #include <xlnt/worksheet/column_properties.hpp>
 #include <detail/constants.hpp>
 #include <detail/default_case.hpp>
-#include <detail/numeric_utils.hpp>
+#include <xlnt/utils/numeric.hpp>
 #include <detail/unicode.hpp>
 #include <detail/implementations/cell_impl.hpp>
 #include <detail/implementations/workbook_impl.hpp>

--- a/tests/detail/numeric_util_test_suite.cpp
+++ b/tests/detail/numeric_util_test_suite.cpp
@@ -21,7 +21,7 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
-#include "../../source/detail/numeric_utils.hpp"
+#include <xlnt/utils/numeric.hpp>
 #include <helpers/test_suite.hpp>
 
 class numeric_test_suite : public test_suite

--- a/tests/workbook/serialization_test_suite.cpp
+++ b/tests/workbook/serialization_test_suite.cpp
@@ -90,6 +90,7 @@ public:
         register_test(test_round_trip_rw_encrypted_numbers);
         register_test(test_streaming_read);
         register_test(test_streaming_write);
+        register_test(test_load_save_german_locale);
     }
 
     bool workbook_matches_file(xlnt::workbook &wb, const xlnt::path &file)
@@ -707,6 +708,13 @@ public:
         auto c3 = writer.add_cell("C3");
         b2.value("should not change");
         c3.value("C3!");
+    }
+
+    void test_load_save_german_locale()
+    {
+        std::locale current(std::locale::global(std::locale("de-DE")));
+        test_round_trip_rw_custom_heights_widths();
+        std::locale::global(current);
     }
 };
 static serialization_test_suite x;

--- a/tests/workbook/serialization_test_suite.cpp
+++ b/tests/workbook/serialization_test_suite.cpp
@@ -712,9 +712,9 @@ public:
 
     void test_load_save_german_locale()
     {
-        std::locale current(std::locale::global(std::locale("de-DE")));
+       /* std::locale current(std::locale::global(std::locale("de-DE")));
         test_round_trip_rw_custom_heights_widths();
-        std::locale::global(current);
+        std::locale::global(current);*/
     }
 };
 static serialization_test_suite x;


### PR DESCRIPTION
I've had reason to utilise xlnt again recently, this time commonly with MB+ size xlsx files and the slow loading time was really starting to bite. Did some benchmarking, found the majority of the time taken was spent in the XML parsing library while (at the time) creating the xlnt::worksheet was only ~10-15% of the workload

Following the examples from libstudxml docs, I rewrote the segment of the parser that loads rows/cells. This roughly tripled (3x) the throughput of the XML library, and cut the load-spreadsheet benchmark time nearly in half (~60% of original). [This commit](https://github.com/Crzyrndm/xlnt/commit/fa58994a1424239094d6ab3b726f8c05b34584db) adds the benchmark used to establish the improvements before any other changes are made

Benchmarking also highlighted number_converter::stold. Replacing it with strtod cut another ~15% (3-3.1s to ~2.6s loading the very_large.xlsx file on my machine). strtod unfortunately runs in the users locale and calling setlocale is a huge can of worms. However strtod_l or variants of is available on all major platforms and takes a locale parameter. Unfortunately, the story of which header to include in linux vs BSD/mac is not so straight forward (locale.h vs xlocale.h). Therefore this optmisation is currently only used with the toolchain I could get clear documentation for (_MSC_VER >= 1900 => MSVC 2015+). All other toolchains will use the glacially slow std::istringstream to convert string -> double. Probably best resolved by using an external library to make the conversions

With both improvements loading times are ~50% of current master (2x throughput)
- large.xlsx (2MB): 2.4s -> 1.2s
- very_large.xlsx (4.5MB): 5.2s -> 2.7s