### PR TITLE
Fixed gcc 5 build bug

### DIFF
--- a/source/detail/serialization/custom_value_traits.cpp
+++ b/source/detail/serialization/custom_value_traits.cpp
@@ -347,11 +347,11 @@ std::string to_string(orientation orientation)
 {
     switch (orientation)
     {
-    case orientation::default_orientation:
+      case xlnt::orientation::default_orientation:
         return "default";
-    case orientation::landscape:
+      case xlnt::orientation::landscape:
         return "landscape";
-    case orientation::portrait:
+      case xlnt::orientation::portrait:
         return "portrait";
     }
     default_case("default");

--- a/source/detail/serialization/custom_value_traits.cpp
+++ b/source/detail/serialization/custom_value_traits.cpp
@@ -347,11 +347,11 @@ std::string to_string(orientation orientation)
 {
     switch (orientation)
     {
-      case xlnt::orientation::default_orientation:
+    case xlnt::orientation::default_orientation:
         return "default";
-      case xlnt::orientation::landscape:
+    case xlnt::orientation::landscape:
         return "landscape";
-      case xlnt::orientation::portrait:
+    case xlnt::orientation::portrait:
         return "portrait";
     }
     default_case("default");


### PR DESCRIPTION
I suffered from a bug like #385. Build fails as shown below.

```bash
/home/yschung/lib/xlnt/source/detail/serialization/custom_value_traits.cpp:350:10: error: ‘orientation’ is not a class, namespace, or enumeration
     case orientation::default_orientation:
```
In my opinion, this issue is not a grammatically incorrect BUG. This is compiler issue.

My environment was g++ (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 201609.
I've tested with some other compiler settings. The issue does not occur with **g++6 and clang**.

However, as I modified xlnt namespace explicitly, the build was successful in g++ 5.4 (I don't know why.)
```c++
// case orientation::default_orientation:
case xlnt::orientation::default_orientation:
        return "default";
// case orientation::landscape:
case xlnt::orientation::landscape:
        return "landscape";
// case orientation::portrait:
case xlnt::orientation::portrait:
        return "portrait";
```

I am sure that this is not a grammar problem. Because the next code works without the namespace in same environment.
```c++
std::string to_string (orientation orientation) // it worked without namespace!
{
```

But with g++ 5.4, there may be people who suffer like me. So I post my PR. This modification might be allopathy, but it works well enough and fixes #385 
