### PR TITLE
microbenchmarks for double<->string conversion, serialisation improvements

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -41,3 +41,8 @@ foreach(BENCHMARK_SOURCE IN ITEMS ${BENCHMARK_SOURCES})
       $<TARGET_FILE_DIR:${BENCHMARK_EXECUTABLE}>)
   endif()
 endforeach()
+
+option(XLNT_MICROBENCH_ENABLED "Enable small benchmarks typically used for development" OFF)
+if (XLNT_MICROBENCH_ENABLED)
+	add_subdirectory(microbenchmarks)
+endif()

--- a/benchmarks/microbenchmarks/CMakeLists.txt
+++ b/benchmarks/microbenchmarks/CMakeLists.txt
@@ -1,0 +1,36 @@
+# FetchContent added in cmake v3.11
+# https://cmake.org/cmake/help/v3.11/module/FetchContent.html
+# this file is behind a feature flag (XLNT_MICROBENCH_ENABLED) so the primary build is not affected
+cmake_minimum_required(VERSION 3.11)
+project(xlnt_ubench)
+
+# acquire google benchmark dependency
+# disable generation of the various test projects
+set(BENCHMARK_ENABLE_TESTING OFF)
+# gtest not required
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
+
+include(FetchContent)
+FetchContent_Declare(
+	googlebenchmark
+	GIT_REPOSITORY 	https://github.com/google/benchmark
+	GIT_TAG			v1.5.0
+)
+# download if not already present
+FetchContent_GetProperties(googlebenchmark)
+if(NOT googlebenchmark_POPULATED)
+	FetchContent_Populate(googlebenchmark)
+	add_subdirectory(${googlebenchmark_SOURCE_DIR} ${googlebenchmark_BINARY_DIR})
+endif()
+# equivalent of add_subdirectory, now available for use
+FetchContent_MakeAvailable(googlebenchmark)
+
+
+add_executable(xlnt_ubench)
+target_sources(xlnt_ubench
+	PRIVATE
+		string_to_double.cpp
+		double_to_string.cpp
+)
+target_link_libraries(xlnt_ubench benchmark_main xlnt)
+target_compile_features(xlnt_ubench PRIVATE cxx_std_17)

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -1,0 +1,2 @@
+#include "benchmark/benchmark.h"
+

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -96,25 +96,32 @@ public:
 
 class number_serialiser_mk2
 {
-    bool should_convert_to_comma;
+    static constexpr int Excel_Digit_Precision = 15; //sf
+    bool should_convert_comma;
+
+    void convert_comma(char *buf, int len)
+    {
+        char *buf_end = buf + len;
+        char *decimal = std::find(buf, buf_end, ',');
+        if (decimal != buf_end)
+        {
+            *decimal = '.';
+        }
+    }
 
 public:
     explicit number_serialiser_mk2()
-        : should_convert_to_comma(std::use_facet<std::numpunct<char>>(std::locale{}).decimal_point() == ',')
+        : should_convert_comma(std::use_facet<std::numpunct<char>>(std::locale{}).decimal_point() == ',')
     {
     }
 
     std::string serialise(double d)
     {
-        char buf[16];
+        char buf[Excel_Digit_Precision + 1]; // need space for trailing '\0'
         int len = snprintf(buf, sizeof(buf), "%16f", d);
-        if (should_convert_to_comma)
+        if (should_convert_comma)
         {
-            auto decimal = std::find(buf, buf + len, ',');
-            if (decimal != buf + len)
-            {
-                *decimal = '.';
-            }
+            convert_comma(buf, len);
         }
         return std::string(buf, len);
     }

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -1,2 +1,151 @@
-#include "benchmark/benchmark.h"
+// A core part of the xlsx serialisation routine is taking doubles from memory and stringifying them
+// this has a few requirements
+// - expect strings in the form 1234.56 (i.e. no thousands seperator, '.' used for the decimal seperator)
+// - outputs up to 15 significant figures (excel only serialises numbers up to 15sf)
 
+#include "benchmark/benchmark.h"
+#include <locale>
+#include <random>
+#include <sstream>
+
+namespace {
+
+// setup a large quantity of random doubles as strings
+template <bool Decimal_Locale = true>
+class RandomFloats : public benchmark::Fixture
+{
+    static constexpr size_t Number_of_Elements = 1 << 20;
+    static_assert(Number_of_Elements > 1'000'000, "ensure a decent set of random values is generated");
+
+    std::vector<double> inputs;
+
+    size_t index = 0;
+    const char *locale_str = nullptr;
+
+public:
+    void SetUp(const ::benchmark::State &state)
+    {
+        if (Decimal_Locale)
+        {
+            locale_str = setlocale(LC_ALL, "C");
+        }
+        else
+        {
+            locale_str = setlocale(LC_ALL, "de-DE");
+        }
+        std::random_device rd; // obtain a seed for the random number engine
+        std::mt19937 gen(rd());
+        // doing full range is stupid (<double>::min/max()...), it just ends up generating very large numbers
+        // uniform is probably not the best distribution to use here, but it will do for now
+        std::uniform_real_distribution<double> dis(-1'000, 1'000);
+        // generate a large quantity of doubles to deserialise
+        inputs.reserve(Number_of_Elements);
+        for (int i = 0; i < Number_of_Elements; ++i)
+        {
+            double d = dis(gen);
+            inputs.push_back(d);
+        }
+    }
+
+    void TearDown(const ::benchmark::State &state)
+    {
+        // restore locale
+        setlocale(LC_ALL, locale_str);
+        // gbench is keeping the fixtures alive somewhere, need to clear the data after use
+        inputs = std::vector<double>{};
+    }
+
+    double &get_rand()
+    {
+        return inputs[++index & (Number_of_Elements - 1)];
+    }
+};
+
+/// Takes in a double and outputs a string form of that number which will
+/// serialise and deserialise without loss of precision
+std::string serialize_number_to_string(double num)
+{
+    // more digits and excel won't match
+    constexpr int Excel_Digit_Precision = 15; //sf
+    std::stringstream ss;
+    ss.precision(Excel_Digit_Precision);
+    ss << num;
+    return ss.str();
+}
+
+class number_serialiser
+{
+    static constexpr int Excel_Digit_Precision = 15; //sf
+    std::ostringstream ss;
+
+public:
+    explicit number_serialiser()
+    {
+        ss.precision(Excel_Digit_Precision);
+        ss.imbue(std::locale("C"));
+    }
+
+    std::string serialise(double d)
+    {
+        ss.str(""); // reset string buffer
+        ss.clear(); // reset any error flags
+        ss << d;
+        return ss.str();
+    }
+};
+
+using RandFloats = RandomFloats<true>;
+} // namespace
+
+BENCHMARK_F(RandFloats, string_from_double_sstream)
+(benchmark::State &state)
+{
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            serialize_number_to_string(get_rand()));
+    }
+}
+
+BENCHMARK_F(RandFloats, string_from_double_sstream_cached)
+(benchmark::State &state)
+{
+    number_serialiser ser;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            ser.serialise(get_rand()));
+    }
+}
+
+BENCHMARK_F(RandFloats, string_from_double_snprintf)
+(benchmark::State &state)
+{
+    while (state.KeepRunning())
+    {
+        char buf[16];
+        int len = snprintf(buf, sizeof(buf), "%16f", get_rand());
+
+        benchmark::DoNotOptimize(
+            std::string(buf, len));
+    }
+}
+
+// locale names are different between OS's, and std::from_chars is only complete in MSVC
+#ifdef _MSC_VER
+
+#include <charconv>
+BENCHMARK_F(RandFloats, string_from_double_std_to_chars)
+(benchmark::State &state)
+{
+    while (state.KeepRunning())
+    {
+        char buf[16];
+        std::to_chars_result result = std::to_chars(buf, buf + std::size(buf), get_rand());
+
+        benchmark::DoNotOptimize(
+            std::string(buf, result.ptr));
+    }
+}
+
+#endif

--- a/benchmarks/microbenchmarks/double_to_string.cpp
+++ b/benchmarks/microbenchmarks/double_to_string.cpp
@@ -118,7 +118,7 @@ public:
     std::string serialise(double d)
     {
         char buf[Excel_Digit_Precision + 1]; // need space for trailing '\0'
-        int len = snprintf(buf, sizeof(buf), "%16f", d);
+        int len = snprintf(buf, sizeof(buf), "%.15g", d);
         if (should_convert_comma)
         {
             convert_comma(buf, len);
@@ -158,7 +158,7 @@ BENCHMARK_F(RandFloats, string_from_double_snprintf)
     while (state.KeepRunning())
     {
         char buf[16];
-        int len = snprintf(buf, sizeof(buf), "%16f", get_rand());
+        int len = snprintf(buf, sizeof(buf), "%.15g", get_rand());
 
         benchmark::DoNotOptimize(
             std::string(buf, len));

--- a/benchmarks/microbenchmarks/string_to_double.cpp
+++ b/benchmarks/microbenchmarks/string_to_double.cpp
@@ -1,0 +1,219 @@
+// A core part of the xlsx parsing routine is taking strings from the xml parser and parsing these to a double
+// this has a few requirements
+// - expect numbers in the form 1234.56 (i.e. no thousands seperator, '.' used for the decimal seperator)
+// - handles atleast 15 significant figures (excel only serialises numbers up to 15sf)
+
+#include <benchmark/benchmark.h>
+#include <locale>
+#include <random>
+
+// setup a large quantity of random doubles as strings
+template <bool Decimal_Locale = true>
+class RandomFloats : public benchmark::Fixture
+{
+    static constexpr size_t Number_of_Elements = 1 << 20;
+    static_assert(Number_of_Elements > 1'000'000, "ensure a decent set of random values is generated");
+
+    std::vector<std::string> inputs;
+
+    size_t index = 0;
+    const char *locale_str;
+
+public:
+    void SetUp(const ::benchmark::State &state)
+    {
+        if (Decimal_Locale)
+        {
+            locale_str = setlocale(LC_ALL, "C");
+        }
+        else
+        {
+            locale_str = setlocale(LC_ALL, "de-DE");
+        }
+        std::random_device rd; // obtain a seed for the random number engine
+        std::mt19937 gen(rd());
+        // doing full range is stupid (<double>::min/max()...), it just ends up generating very large numbers
+        // uniform is probably not the best distribution to use here, but it will do for now
+        std::uniform_real_distribution<double> dis(-1'000, 1'000);
+        // generate a large quantity of doubles to deserialise
+        inputs.reserve(Number_of_Elements);
+        for (int i = 0; i < Number_of_Elements; ++i)
+        {
+            double d = dis(gen);
+            char buf[16];
+            snprintf(buf, 16, "%.15f", d);
+            inputs.push_back(std::string(buf));
+        }
+    }
+
+    void TearDown(const ::benchmark::State &state)
+    {
+        // restore locale
+        setlocale(LC_ALL, locale_str);
+        // gbench is keeping the fixtures alive somewhere, need to clear the data...
+        inputs = std::vector<std::string>{};
+    }
+
+    std::string &get_rand()
+    {
+        return inputs[++index & Number_of_Elements];
+    }
+};
+
+// method used by xlsx_consumer.cpp in commit - ba01de47a7d430764c20ec9ac9600eec0eb38bcf
+// std::istringstream with the locale set to "C"
+#include <sstream>
+struct number_converter
+{
+    number_converter()
+    {
+        stream.imbue(std::locale("C"));
+    }
+
+    double stold(const std::string &s)
+    {
+        stream.str(s);
+        stream.clear();
+        stream >> result;
+        return result;
+    }
+
+    std::istringstream stream;
+    double result;
+};
+
+using RandFloats = RandomFloats<true>;
+
+BENCHMARK_F(RandFloats, double_from_string_sstream)
+(benchmark::State &state)
+{
+    number_converter converter;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            converter.stold(get_rand()));
+    }
+}
+
+// using strotod
+// https://en.cppreference.com/w/cpp/string/byte/strtof
+// this naive usage is broken in the face of locales (fails condition 1)
+#include <cstdlib>
+BENCHMARK_F(RandFloats, double_from_string_strtod)
+(benchmark::State &state)
+{
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            strtod(get_rand().c_str(), nullptr));
+    }
+}
+
+// to resolve the locale issue with strtod, a little preprocessing of the input is required
+struct number_converter_mk2
+{
+    explicit number_converter_mk2()
+        : should_convert_to_comma(std::use_facet<std::numpunct<char>>(std::locale{}).decimal_point() == ',')
+    {
+    }
+
+    double stold(std::string &s) const noexcept
+    {
+        assert(!s.empty());
+        if (should_convert_to_comma)
+        {
+            auto decimal_pt = std::find(s.begin(), s.end(), '.');
+            if (decimal_pt != s.end())
+            {
+                *decimal_pt = ',';
+            }
+        }
+        return strtod(s.c_str(), nullptr);
+    }
+
+    double stold(const std::string &s) const
+    {
+        assert(!s.empty());
+        if (!should_convert_to_comma)
+        {
+            return strtod(s.c_str(), nullptr);
+        }
+        std::string copy(s);
+        auto decimal_pt = std::find(copy.begin(), copy.end(), '.');
+        if (decimal_pt != copy.end())
+        {
+            *decimal_pt = ',';
+        }
+        return strtod(copy.c_str(), nullptr);
+    }
+
+private:
+    bool should_convert_to_comma = false;
+};
+
+BENCHMARK_F(RandFloats, double_from_string_strtod_fixed)
+(benchmark::State &state)
+{
+    number_converter_mk2 converter;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            converter.stold(get_rand()));
+    }
+}
+
+BENCHMARK_F(RandFloats, double_from_string_strtod_fixed_const_ref)
+(benchmark::State &state)
+{
+    number_converter_mk2 converter;
+    while (state.KeepRunning())
+    {
+        const std::string &inp = get_rand();
+        benchmark::DoNotOptimize(
+            converter.stold(inp));
+    }
+}
+
+// locale names are different between OS's, and std::from_chars is only complete in MSVC
+#ifdef _MSC_VER
+
+#include <charconv>
+BENCHMARK_F(RandFloats, double_from_string_std_from_chars)
+(benchmark::State &state)
+{
+    while (state.KeepRunning())
+    {
+        const std::string &input = get_rand();
+        double output;
+        benchmark::DoNotOptimize(
+            std::from_chars(input.data(), input.data() + input.size(), output));
+    }
+}
+
+// not using the standard "C" locale with '.' seperator
+// german locale uses ',' as the seperator
+using RandFloatsComma = RandomFloats<false>;
+BENCHMARK_F(RandFloatsComma, double_from_string_strtod_fixed_comma_ref)
+(benchmark::State &state)
+{
+    number_converter_mk2 converter;
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(
+            converter.stold(get_rand()));
+    }
+}
+
+BENCHMARK_F(RandFloatsComma, double_from_string_strtod_fixed_comma_const_ref)
+(benchmark::State &state)
+{
+    number_converter_mk2 converter;
+    while (state.KeepRunning())
+    {
+        const std::string &inp = get_rand();
+        benchmark::DoNotOptimize(
+            converter.stold(inp));
+    }
+}
+
+#endif

--- a/benchmarks/spreadsheet-load.cpp
+++ b/benchmarks/spreadsheet-load.cpp
@@ -5,7 +5,7 @@
 namespace {
 using milliseconds_d = std::chrono::duration<double, std::milli>;
 
-void run_test(const xlnt::path &file, int runs = 10)
+void run_load_test(const xlnt::path &file, int runs = 10)
 {
     std::cout << file.string() << "\n\n";
 
@@ -24,10 +24,35 @@ void run_test(const xlnt::path &file, int runs = 10)
         std::cout << milliseconds_d(test_timings.back()).count() << " ms\n";
     }
 }
+
+void run_save_test(const xlnt::path &file, int runs = 10)
+{
+    std::cout << file.string() << "\n\n";
+
+    xlnt::workbook wb;
+    wb.load(file);
+    const xlnt::path save_path(file.filename());
+
+    std::vector<std::chrono::steady_clock::duration> test_timings;
+
+    for (int i = 0; i < runs; ++i)
+    {
+        auto start = std::chrono::steady_clock::now();
+
+        wb.save(save_path);
+
+        auto end = std::chrono::steady_clock::now();
+        test_timings.push_back(end - start);
+        std::cout << milliseconds_d(test_timings.back()).count() << " ms\n";
+    }
+}
 } // namespace
 
 int main()
 {
     run_test(path_helper::benchmark_file("large.xlsx"));
     run_test(path_helper::benchmark_file("very_large.xlsx"));
+
+    run_save_test(path_helper::benchmark_file("large.xlsx"));
+    run_save_test(path_helper::benchmark_file("very_large.xlsx"));
 }

--- a/benchmarks/spreadsheet-load.cpp
+++ b/benchmarks/spreadsheet-load.cpp
@@ -50,8 +50,8 @@ void run_save_test(const xlnt::path &file, int runs = 10)
 
 int main()
 {
-    run_test(path_helper::benchmark_file("large.xlsx"));
-    run_test(path_helper::benchmark_file("very_large.xlsx"));
+    run_load_test(path_helper::benchmark_file("large.xlsx"));
+    run_load_test(path_helper::benchmark_file("very_large.xlsx"));
 
     run_save_test(path_helper::benchmark_file("large.xlsx"));
     run_save_test(path_helper::benchmark_file("very_large.xlsx"));

--- a/include/xlnt/cell/index_types.hpp
+++ b/include/xlnt/cell/index_types.hpp
@@ -93,24 +93,9 @@ public:
     column_t(const char *column_string);
 
     /// <summary>
-    /// Copy constructor. Constructs a column by copying it from other.
-    /// </summary>
-    column_t(const column_t &other);
-
-    /// <summary>
-    /// Move constructor. Constructs a column by moving it from other.
-    /// </summary>
-    column_t(column_t &&other);
-
-    /// <summary>
     /// Returns a string representation of this column index.
     /// </summary>
     std::string column_string() const;
-
-    /// <summary>
-    /// Sets this column to be the same as rhs's and return reference to self.
-    /// </summary>
-    column_t &operator=(column_t rhs);
 
     /// <summary>
     /// Sets this column to be equal to rhs and return reference to self.

--- a/include/xlnt/utils/numeric.hpp
+++ b/include/xlnt/utils/numeric.hpp
@@ -163,7 +163,7 @@ public:
             return strtod(s.c_str(), nullptr);
         }
         char buf[30];
-        assert(s.size() < std::size(buf));
+        assert(s.size() < sizeof(buf));
         auto copy_end = std::copy(s.begin(), s.end(), buf);
         convert_pt_to_comma(buf, static_cast<size_t>(copy_end - buf));
         return strtod(buf, nullptr);

--- a/include/xlnt/utils/numeric.hpp
+++ b/include/xlnt/utils/numeric.hpp
@@ -141,7 +141,7 @@ public:
         {
             convert_comma_to_pt(buf, len);
         }
-        return std::string(buf, len);
+        return std::string(buf, static_cast<size_t>(len));
     }
 
     double deserialise(std::string &s) const noexcept

--- a/include/xlnt/worksheet/range_reference.hpp
+++ b/include/xlnt/worksheet/range_reference.hpp
@@ -69,8 +69,6 @@ public:
     range_reference(column_t column_index_start, row_t row_index_start,
         column_t column_index_end, row_t row_index_end);
 
-    range_reference(const range_reference &ref);
-
     /// <summary>
     /// Returns true if the range has a width and height of 1 cell.
     /// </summary>

--- a/include/xlnt/worksheet/range_reference.hpp
+++ b/include/xlnt/worksheet/range_reference.hpp
@@ -149,11 +149,6 @@ public:
     /// </summary>
     bool operator!=(const char *reference_string) const;
 
-    /// <summary>
-    /// Assigns the extents of the provided range to this range.
-    /// </summary>
-    range_reference &operator=(const range_reference &ref);
-
 private:
     /// <summary>
     /// The top left cell in the range

--- a/source/cell/cell.cpp
+++ b/source/cell/cell.cpp
@@ -199,7 +199,7 @@ cell::cell(detail::cell_impl *d)
 
 bool cell::garbage_collectible() const
 {
-    return !(has_value() || is_merged() || phonetics_visible() || has_formula() || has_format() || has_hyperlink());
+    return d_->is_garbage_collectible();
 }
 
 void cell::value(std::nullptr_t)

--- a/source/cell/index_types.cpp
+++ b/source/cell/index_types.cpp
@@ -109,25 +109,9 @@ column_t::column_t(const char *column_string)
 {
 }
 
-column_t::column_t(const column_t &other)
-    : column_t(other.index)
-{
-}
-
-column_t::column_t(column_t &&other)
-{
-    swap(*this, other);
-}
-
 std::string column_t::column_string() const
 {
     return column_string_from_index(index);
-}
-
-column_t &column_t::operator=(column_t rhs)
-{
-    swap(*this, rhs);
-    return *this;
 }
 
 column_t &column_t::operator=(const std::string &rhs)

--- a/source/detail/header_footer/header_footer_code.cpp
+++ b/source/detail/header_footer/header_footer_code.cpp
@@ -27,7 +27,7 @@
 namespace xlnt {
 namespace detail {
 
-std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::string &hf_string)
+std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::string &hf_string, const number_serialiser &serialiser)
 {
     std::array<xlnt::optional<xlnt::rich_text>, 3> result;
 
@@ -216,7 +216,7 @@ std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::s
         tokens.push_back(token);
     }
 
-    const auto parse_section = [&tokens, &result](hf_code code) {
+    const auto parse_section = [&tokens, &result, &serialiser](hf_code code) {
         std::vector<hf_code> end_codes{hf_code::left_section, hf_code::center_section, hf_code::right_section};
         end_codes.erase(std::find(end_codes.begin(), end_codes.end(), code));
 
@@ -297,7 +297,7 @@ std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::s
                     current_run.second = xlnt::font();
                 }
 
-                current_run.second.get().size(std::stod(current_token.value));
+                current_run.second.get().size(serialiser.deserialise(current_token.value));
 
                 break;
             }
@@ -460,7 +460,7 @@ std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::s
     return result;
 }
 
-std::string encode_header_footer(const rich_text &t, header_footer::location where)
+std::string encode_header_footer(const rich_text &t, header_footer::location where, const number_serialiser &serialiser)
 {
     const auto location_code_map =
         std::unordered_map<header_footer::location,
@@ -505,7 +505,7 @@ std::string encode_header_footer(const rich_text &t, header_footer::location whe
             if (run.second.get().has_size())
             {
                 encoded.push_back('&');
-                encoded.append(serialize_number_to_string(run.second.get().size()));
+                encoded.append(serialiser.serialise(run.second.get().size()));
             }
             if (run.second.get().underlined())
             {

--- a/source/detail/header_footer/header_footer_code.hpp
+++ b/source/detail/header_footer/header_footer_code.hpp
@@ -27,12 +27,13 @@
 #include <xlnt/cell/rich_text.hpp>
 #include <xlnt/utils/optional.hpp>
 #include <xlnt/worksheet/header_footer.hpp>
+#include <xlnt/utils/numeric.hpp>
 
 namespace xlnt {
 namespace detail {
 
-std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::string &hf_string);
-std::string encode_header_footer(const rich_text &t, header_footer::location where);
+std::array<xlnt::optional<xlnt::rich_text>, 3> decode_header_footer(const std::string &hf_string, const number_serialiser &serialiser);
+std::string encode_header_footer(const rich_text &t, header_footer::location where, const number_serialiser& serialiser);
 
 } // namespace detail
 } // namespace xlnt

--- a/source/detail/implementations/cell_impl.hpp
+++ b/source/detail/implementations/cell_impl.hpp
@@ -47,7 +47,7 @@ struct cell_impl
     cell_impl(cell_impl &&other) = default;
     cell_impl &operator=(const cell_impl &other) = default;
     cell_impl &operator=(cell_impl &&other) = default;
-    
+
     cell_type type_;
 
     worksheet_impl *parent_;
@@ -65,6 +65,11 @@ struct cell_impl
     optional<hyperlink_impl> hyperlink_;
     optional<format_impl *> format_;
     optional<comment *> comment_;
+
+    bool is_garbage_collectible() const
+    {
+        return !(type_ != cell_type::empty || is_merged_ || phonetics_visible_ || formula_.is_set() || format_.is_set() || hyperlink_.is_set());
+    }
 };
 
 inline bool operator==(const cell_impl &lhs, const cell_impl &rhs)

--- a/source/detail/serialization/xlsx_consumer.hpp
+++ b/source/detail/serialization/xlsx_consumer.hpp
@@ -416,7 +416,7 @@ private:
     detail::cell_impl *current_cell_;
 
     detail::worksheet_impl *current_worksheet_;
-    number_converter converter_;
+    number_serialiser converter_;
 };
 
 } // namespace detail

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2267,16 +2267,18 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         {
             write_attribute("enableFormatConditionsCalculation", props.enable_format_condition_calculation.get());
         }
-
+        // outlinePr is optional in the spec but is being written every time?
         write_start_element(xmlns, "outlinePr");
         write_attribute("summaryBelow", "1");
         write_attribute("summaryRight", "1");
         write_end_element(xmlns, "outlinePr");
 
-        write_start_element(xmlns, "pageSetUpPr");
-        write_attribute("fitToPage", write_bool(ws.page_setup().fit_to_page()));
-        write_end_element(xmlns, "pageSetUpPr");
-
+        if (ws.has_page_setup())
+        {
+            write_start_element(xmlns, "pageSetUpPr");
+            write_attribute("fitToPage", write_bool(ws.page_setup().fit_to_page()));
+            write_end_element(xmlns, "pageSetUpPr");
+        }
         write_end_element(xmlns, "sheetPr");
     }
 

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2483,12 +2483,19 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         {
             for (auto column = dimension.top_left().column(); column <= dimension.bottom_right().column(); ++column)
             {
-                if (!ws.has_cell(cell_reference(column, check_row))) continue;
-                auto cell = ws.cell(cell_reference(column, check_row));
-                if (cell.garbage_collectible()) continue;
+                auto ref = cell_reference(column, check_row);
+                auto cell = ws.d_->cell_map_.find(ref);
+                if (cell == ws.d_->cell_map_.end())
+                {
+                    continue;
+                }
+                if (cell->second.is_garbage_collectible())
+                {
+                    continue;
+                }
 
-                first_block_column = std::min(first_block_column, cell.column());
-                last_block_column = std::max(last_block_column, cell.column());
+                first_block_column = std::min(first_block_column, cell->second.column_);
+                last_block_column = std::max(last_block_column, cell->second.column_);
 
                 if (row == check_row)
                 {

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2420,7 +2420,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         if (props.width.is_set())
         {
             double width = (props.width.get() * 7 + 5) / 7;
-            write_attribute("width", serialize_number_to_string(width));
+            write_attribute("width", converter_.serialise(width));
         }
 
         if (props.best_fit)
@@ -2522,7 +2522,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
             if (props.height.is_set())
             {
                 auto height = props.height.get();
-                write_attribute("ht", serialize_number_to_string(height));
+                write_attribute("ht", converter_.serialise(height));
             }
 
             if (props.hidden)
@@ -2649,7 +2649,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
 
                 case cell::type::number:
                     write_start_element(xmlns, "v");
-                    write_characters(serialize_number_to_string(cell.value<double>()));
+                    write_characters(converter_.serialise(cell.value<double>()));
                     write_end_element(xmlns, "v");
                     break;
 
@@ -2886,26 +2886,26 @@ void xlsx_producer::write_worksheet(const relationship &rel)
             {
                 if (hf.has_odd_even_header(location))
                 {
-                    odd_header.append(encode_header_footer(hf.odd_header(location), location));
-                    even_header.append(encode_header_footer(hf.even_header(location), location));
+                    odd_header.append(encode_header_footer(hf.odd_header(location), location, converter_));
+                    even_header.append(encode_header_footer(hf.even_header(location), location, converter_));
                 }
 
                 if (hf.has_odd_even_footer(location))
                 {
-                    odd_footer.append(encode_header_footer(hf.odd_footer(location), location));
-                    even_footer.append(encode_header_footer(hf.even_footer(location), location));
+                    odd_footer.append(encode_header_footer(hf.odd_footer(location), location, converter_));
+                    even_footer.append(encode_header_footer(hf.even_footer(location), location, converter_));
                 }
             }
             else
             {
                 if (hf.has_header(location))
                 {
-                    odd_header.append(encode_header_footer(hf.header(location), location));
+                    odd_header.append(encode_header_footer(hf.header(location), location, converter_));
                 }
 
                 if (hf.has_footer(location))
                 {
-                    odd_footer.append(encode_header_footer(hf.footer(location), location));
+                    odd_footer.append(encode_header_footer(hf.footer(location), location, converter_));
                 }
             }
 
@@ -2913,12 +2913,12 @@ void xlsx_producer::write_worksheet(const relationship &rel)
             {
                 if (hf.has_first_page_header(location))
                 {
-                    first_header.append(encode_header_footer(hf.first_page_header(location), location));
+                    first_header.append(encode_header_footer(hf.first_page_header(location), location, converter_));
                 }
 
                 if (hf.has_first_page_footer(location))
                 {
-                    first_footer.append(encode_header_footer(hf.first_page_footer(location), location));
+                    first_footer.append(encode_header_footer(hf.first_page_footer(location), location, converter_));
                 }
             }
         }
@@ -3385,7 +3385,7 @@ void xlsx_producer::write_color(const xlnt::color &color)
     }
     if (color.has_tint())
     {
-        write_attribute("tint", serialize_number_to_string(color.tint()));
+        write_attribute("tint", converter_.serialise(color.tint()));
     }
 }
 

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -30,6 +30,7 @@
 
 #include <detail/constants.hpp>
 #include <detail/external/include_libstudxml.hpp>
+#include <xlnt/utils/numeric.hpp>
 
 namespace xml {
 class serializer;
@@ -208,6 +209,7 @@ private:
     detail::cell_impl *current_cell_;
 
     detail::worksheet_impl *current_worksheet_;
+    detail::number_serialiser converter_;
 };
 
 } // namespace detail

--- a/source/worksheet/range_reference.cpp
+++ b/source/worksheet/range_reference.cpp
@@ -177,11 +177,4 @@ XLNT_API bool operator!=(const char *reference_string, const range_reference &re
     return ref != reference_string;
 }
 
-range_reference &range_reference::operator=(const range_reference &ref)
-{
-    top_left_ = ref.top_left_;
-    bottom_right_ = ref.bottom_right_;
-    return *this;
-}
-
 } // namespace xlnt

--- a/source/worksheet/range_reference.cpp
+++ b/source/worksheet/range_reference.cpp
@@ -46,12 +46,6 @@ range_reference::range_reference(const char *range_string)
 {
 }
 
-range_reference::range_reference(const range_reference &ref)
-{
-    top_left_ = ref.top_left_;
-    bottom_right_ = ref.bottom_right_;
-}
-
 range_reference::range_reference(const std::string &range_string)
     : top_left_("A1"), bottom_right_("A1")
 {

--- a/tests/detail/numeric_util_test_suite.cpp
+++ b/tests/detail/numeric_util_test_suite.cpp
@@ -40,17 +40,18 @@ public:
 
     void test_serialise_number()
     {
+        xlnt::detail::number_serialiser serialiser;
         // excel serialises numbers as floating point values with <= 15 digits of precision
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1) == "1");
+        xlnt_assert(serialiser.serialise(1) == "1");
         // trailing zeroes are ignored
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1.0) == "1");
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1.0f) == "1");
+        xlnt_assert(serialiser.serialise(1.0) == "1");
+        xlnt_assert(serialiser.serialise(1.0f) == "1");
         // one to 1 relation
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1.23456) == "1.23456");
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1.23456789012345) == "1.23456789012345");
-        xlnt_assert(xlnt::detail::serialize_number_to_string(123456.789012345) == "123456.789012345");
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1.23456789012345e+67) == "1.23456789012345e+67");
-        xlnt_assert(xlnt::detail::serialize_number_to_string(1.23456789012345e-67) == "1.23456789012345e-67");
+        xlnt_assert(serialiser.serialise(1.23456) == "1.23456");
+        xlnt_assert(serialiser.serialise(1.23456789012345) == "1.23456789012345");
+        xlnt_assert(serialiser.serialise(123456.789012345) == "123456.789012345");
+        xlnt_assert(serialiser.serialise(1.23456789012345e+67) == "1.23456789012345e+67");
+        xlnt_assert(serialiser.serialise(1.23456789012345e-67) == "1.23456789012345e-67");
     }
 
     void test_float_equals_zero()


### PR DESCRIPTION
This is a continuation of some of the work I did for #421 / #422 a few months ago

Adds a microbenchmark project (enabled by passing -DBENCHMARKS=ON -DXLNT_MICROBENCH_ENABLED=ON to cmake). It uses [google banchmark](https://github.com/google/benchmark). Currently used to compare a variety of ways of (de)serialising numbers.
* gbenchmark dependency aquired using cmake FetchContent module (requires cmake 3.11 as  indicated by the [script](https://github.com/tfussell/xlnt/blob/e8cb8d9bc6f4ac3ce93c77f63a435f0081eefaf0/benchmarks/microbenchmarks/CMakeLists.txt)). find_package is nearly useless on windows, so it was the most hassle free method for a "developer only" tool I could find. I'm open to suggestions on acquisition method

![image](https://user-images.githubusercontent.com/8765278/75624483-6f54fd00-5c19-11ea-826f-964914a46f83.png)
Note: the std::<to/from>_chars and *_comma* benchmarks are currently ifdef'd behind _MSC_VER. This is because 
* to_chars/from_chars only exists in full in MSVC (to my knowledge)
* the locale names are different between OS's and the *_comma* benchmarks use the german locale "de-DE" which uses the ',' as the decimal seperator to benchmark the alternate path in the strtod/snprintf implementations. Not entirely sure how to deal with this across operating systems (I believe Ubuntu requires installing a locale package and the names are different)

The added benchmarks prove that the changes made in #421 around [deserialising numbers](https://github.com/Crzyrndm/xlnt/blob/feature/benchmark/benchmarks/microbenchmarks/string_to_double.cpp) were justified
* stringstream is slow
* replacing the comma has minmal impact on perf (<10%)
* conversion ended up 3-4x faster using strtod
* std::from_chars is currently only a "relatively" minor improvement (30-50% further improvement in throughput up to ~5x stringstream) dwarfed by other factors during file load

Additionally, I added some benchmarks for the [serialisation of numbers](https://github.com/Crzyrndm/xlnt/blob/feature/benchmark/benchmarks/microbenchmarks/double_to_string.cpp) which was not touched during the previous work. These show a roughly 2x improvement in using snprintf instead of stringstream and then a further 5-6x improvement using std::to_chars (>10x stringstream). As such I implemented the snprintf version in xlsx_producer along with a few other tweaks based on some basic profiling. These tweaks reduced time to save a spreadsheet to ~85-90% of current master.

I'm not certain the doubling of throughput from #421 can be recreated in the serialisation routines. Majority of the improvements would have to come from changes to how the xml serialiser is used, but unlike with deserialisation, there doesn't appear to be major inefficiency with the current serialisation method