### PR TITLE
locale aware double->string conversions

### DIFF
--- a/include/xlnt/utils/numeric.hpp
+++ b/include/xlnt/utils/numeric.hpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <sstream>
 #include <type_traits>

--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 
 #include <xlnt/utils/exceptions.hpp>
+#include <xlnt/utils/numeric.hpp>
 #include <detail/default_case.hpp>
 #include <detail/number_format/number_formatter.hpp>
 
@@ -622,7 +623,8 @@ void number_format_parser::parse()
                 value = token.string.substr(1);
             }
 
-            section.condition.value = std::stod(value);
+            detail::number_serialiser ser;
+            section.condition.value = ser.deserialise(value);
             break;
         }
 
@@ -1565,19 +1567,7 @@ std::string number_formatter::fill_placeholders(const format_placeholders &p, do
     if (p.type == format_placeholders::placeholders_type::general
         || p.type == format_placeholders::placeholders_type::text)
     {
-        result = std::to_string(number);
-
-        while (result.back() == '0')
-        {
-            result.pop_back();
-        }
-
-        if (result.back() == '.')
-        {
-            result.pop_back();
-        }
-
-        return result;
+        return serialiser_.serialise_short(number);
     }
 
     if (p.percentage)
@@ -1636,21 +1626,22 @@ std::string number_formatter::fill_placeholders(const format_placeholders &p, do
         auto fractional_part = number - integer_part;
         result = std::fabs(fractional_part) < std::numeric_limits<double>::min()
             ? std::string(".")
-            : std::to_string(fractional_part).substr(1);
+            : serialiser_.serialise_short(fractional_part).substr(1);
 
         while (result.back() == '0' || result.size() > (p.num_zeros + p.num_optionals + p.num_spaces + 1))
         {
             result.pop_back();
         }
 
-        while (result.size() < p.num_zeros + 1)
+        
+        if (result.size() < p.num_zeros + 1)
         {
-            result.push_back('0');
+            result.resize(p.num_zeros + 1, '0');
         }
 
-        while (result.size() < p.num_zeros + p.num_optionals + p.num_spaces + 1)
+        if (result.size() < p.num_zeros + p.num_optionals + p.num_spaces + 1)
         {
-            result.push_back(' ');
+            result.resize(p.num_zeros + p.num_optionals + p.num_spaces + 1, ' ');
         }
 
         if (p.percentage)
@@ -1689,13 +1680,7 @@ std::string number_formatter::fill_scientific_placeholders(const format_placehol
         integer_string = std::string(integer_part.num_zeros + integer_part.num_optionals, '0');
     }
 
-    std::string fractional_string = std::to_string(fraction).substr(1);
-
-    while (fractional_string.size() > fractional_part.num_zeros + fractional_part.num_optionals + 1)
-    {
-        fractional_string.pop_back();
-    }
-
+    std::string fractional_string = serialiser_.serialise_short(fraction).substr(1, fractional_part.num_zeros + fractional_part.num_optionals + 1);
     std::string exponent_string = std::to_string(logarithm);
 
     while (exponent_string.size() < fractional_part.num_zeros)

--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -1567,7 +1567,16 @@ std::string number_formatter::fill_placeholders(const format_placeholders &p, do
     if (p.type == format_placeholders::placeholders_type::general
         || p.type == format_placeholders::placeholders_type::text)
     {
-        return serialiser_.serialise_short(number);
+        auto s = serialiser_.serialise_short(number);
+        while (s.size() > 1 && s.back() == '0')
+        {
+            s.pop_back();
+        }
+        if (s.back() == '.')
+        {
+            s.pop_back();
+        }
+        return s;
     }
 
     if (p.percentage)

--- a/source/detail/number_format/number_formatter.hpp
+++ b/source/detail/number_format/number_formatter.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <xlnt/utils/datetime.hpp>
+#include <xlnt/utils/numeric.hpp>
 
 namespace xlnt {
 namespace detail {
@@ -691,6 +692,7 @@ private:
     number_format_parser parser_;
     std::vector<format_code> format_;
     xlnt::calendar calendar_;
+    xlnt::detail::number_serialiser serialiser_;
 };
 
 } // namespace detail

--- a/source/detail/serialization/serialisation_helpers.hpp
+++ b/source/detail/serialization/serialisation_helpers.hpp
@@ -1,0 +1,96 @@
+#ifndef XLNT_DETAIL_SERIALISATION_HELPERS_HPP
+#define XLNT_DETAIL_SERIALISATION_HELPERS_HPP
+
+#include <xlnt/cell/cell_type.hpp>
+#include <xlnt/cell/index_types.hpp>
+#include <string>
+
+namespace xlnt {
+namespace detail {
+
+/// parsing assumptions used by the following functions
+/// - on entry, the start element for the element has been consumed by parser->next
+/// - on exit, the closing element has been consumed by parser->next
+/// using these assumptions, the following functions DO NOT use parser->peek (SLOW!!!)
+/// probable further gains from not building an attribute map and using the attribute events instead as the impl just iterates the map
+
+/// 'r' == cell reference e.g. 'A1'
+/// https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oe376/db11a912-b1cb-4dff-b46d-9bedfd10cef0
+///
+/// a lightweight version of xlnt::cell_reference with no extre functionality (absolute/relative, ...)
+/// many thousands are created during (de)serialisation, so even minor overhead is noticable
+struct Cell_Reference
+{
+    // the obvious ctor
+    explicit Cell_Reference(xlnt::row_t row_arg, xlnt::column_t::index_t column_arg) noexcept
+        : row(row_arg), column(column_arg)
+    {
+    }
+
+    // the common case. row # is already known during parsing (from parent <row> element)
+    // just need to evaluate the column
+    explicit Cell_Reference(xlnt::row_t row_arg, const std::string &reference) noexcept
+        : row(row_arg)
+    {
+        // only three characters allowed for the column
+        // assumption:
+        // - regex pattern match: [A-Z]{1,3}\d{1,7}
+        const char *iter = reference.c_str();
+        int temp = *iter - 'A' + 1; // 'A' == 1
+        ++iter;
+        if (*iter >= 'A') // second char
+        {
+            temp *= 26; // LHS values are more significant
+            temp += *iter - 'A' + 1; // 'A' == 1
+            ++iter;
+            if (*iter >= 'A') // third char
+            {
+                temp *= 26; // LHS values are more significant
+                temp += *iter - 'A' + 1; // 'A' == 1
+            }
+        }
+        column = static_cast<xlnt::column_t::index_t>(temp);
+    }
+
+    // for sorting purposes
+    bool operator<(const Cell_Reference &rhs)
+    {
+        // row first, serialisation is done by row then column
+        if (row < rhs.row)
+        {
+            return true;
+        }
+        else if (rhs.row < row)
+        {
+            return false;
+        }
+        // same row, column comparison
+        return column < rhs.column;
+    }
+
+    xlnt::row_t row; // range:[1, 1048576]
+    xlnt::column_t::index_t column; // range:["A", "ZZZ"] -> [1, 26^3] -> [1, 17576]
+};
+
+// <c> inside <row> element
+// https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-2.8.1
+struct Cell
+{
+    // sort cells by location, row first
+    bool operator<(const Cell &rhs)
+    {
+        return ref < rhs.ref;
+    }
+
+    bool is_phonetic = false; // 'ph'
+    xlnt::cell_type type = xlnt::cell_type::number; // 't'
+    int cell_metatdata_idx = -1; // 'cm'
+    int style_index = -1; // 's'
+    Cell_Reference ref{0, 0}; // 'r'
+    std::string value; // <v> OR <is>
+    std::string formula_string; // <f>
+};
+
+} // namespace detail
+} // namespace xlnt
+#endif

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -384,9 +384,7 @@ namespace detail {
 
 xlsx_consumer::xlsx_consumer(workbook &target)
     : target_(target),
-      parser_(nullptr),
-      current_cell_(nullptr),
-      current_worksheet_(nullptr)
+      parser_(nullptr)
 {
 }
 

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -384,7 +384,9 @@ namespace detail {
 
 xlsx_consumer::xlsx_consumer(workbook &target)
     : target_(target),
-      parser_(nullptr)
+      parser_(nullptr),
+      current_cell_(nullptr),
+      current_worksheet_(nullptr)
 {
 }
 

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -40,6 +40,7 @@
 #include <detail/header_footer/header_footer_code.hpp>
 #include <detail/implementations/workbook_impl.hpp>
 #include <detail/serialization/custom_value_traits.hpp>
+#include <detail/serialization/serialisation_helpers.hpp>
 #include <detail/serialization/vector_streambuf.hpp>
 #include <detail/serialization/xlsx_consumer.hpp>
 #include <detail/serialization/zstream.hpp>
@@ -127,74 +128,14 @@ void set_style_by_xfid(const std::vector<style_id_pair> &styles,
     }
 }
 
-/// parsing assumptions used by the following functions
-/// - on entry, the start element for the element has been consumed by parser->next
-/// - on exit, the closing element has been consumed by parser->next
-/// using these assumptions, the following functions DO NOT use parser->peek (SLOW!!!)
-/// probable further gains from not building an attribute map and using the attribute events instead as the impl just iterates the map
-
-/// 'r' == cell reference e.g. 'A1'
-/// https://docs.microsoft.com/en-us/openspecs/office_standards/ms-oe376/db11a912-b1cb-4dff-b46d-9bedfd10cef0
-///
-/// a lightweight version of xlnt::cell_reference with no extre functionality (absolute/relative, ...)
-/// many thousands are created during parsing, so even minor overhead is noticable
-struct Cell_Reference
-{
-    // not commonly used, added as the obvious ctor
-    explicit Cell_Reference(xlnt::row_t row_arg, xlnt::column_t::index_t column_arg) noexcept
-        : row(row_arg), column(column_arg)
-    {
-    }
-    // the common case. row # is already known during parsing (from parent <row> element)
-    // just need to evaluate the column
-    explicit Cell_Reference(xlnt::row_t row_arg, const std::string &reference) noexcept
-        : row(row_arg)
-    {
-        // only three characters allowed for the column
-        // assumption:
-        // - regex pattern match: [A-Z]{1,3}\d{1,7}
-        const char *iter = reference.c_str();
-        int temp = *iter - 'A' + 1; // 'A' == 1
-        ++iter;
-        if (*iter >= 'A') // second char
-        {
-            temp *= 26; // LHS values are more significant
-            temp += *iter - 'A' + 1; // 'A' == 1
-            ++iter;
-            if (*iter >= 'A') // third char
-            {
-                temp *= 26; // LHS values are more significant
-                temp += *iter - 'A' + 1; // 'A' == 1
-            }
-        }
-        column = static_cast<xlnt::column_t::index_t>(temp);
-    }
-
-    xlnt::row_t row; // range:[1, 1048576]
-    xlnt::column_t::index_t column; // range:["A", "ZZZ"] -> [1, 26^3] -> [1, 17576]
-};
-
-// <c> inside <row> element
-// https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-2.8.1
-struct Cell
-{
-    bool is_phonetic = false; // 'ph'
-    xlnt::cell::type type = xlnt::cell::type::number; // 't'
-    int cell_metatdata_idx = -1; // 'cm'
-    int style_index = -1; // 's'
-    Cell_Reference ref{0, 0}; // 'r'
-    std::string value; // <v> OR <is>
-    std::string formula_string; // <f>
-};
-
 // <sheetData> element
 struct Sheet_Data
 {
     std::vector<std::pair<xlnt::row_properties, xlnt::row_t>> parsed_rows;
-    std::vector<Cell> parsed_cells;
+    std::vector<xlnt::detail::Cell> parsed_cells;
 };
 
-xlnt::cell::type type_from_string(const std::string &str)
+xlnt::cell_type type_from_string(const std::string &str)
 {
     if (string_equal(str, "s"))
     {
@@ -223,14 +164,14 @@ xlnt::cell::type type_from_string(const std::string &str)
     return xlnt::cell::type::shared_string;
 }
 
-Cell parse_cell(xlnt::row_t row_arg, xml::parser *parser)
+xlnt::detail::Cell parse_cell(xlnt::row_t row_arg, xml::parser *parser)
 {
-    Cell c;
+    xlnt::detail::Cell c;
     for (auto &attr : parser->attribute_map())
     {
         if (string_equal(attr.first.name(), "r"))
         {
-            c.ref = Cell_Reference(row_arg, attr.second.value);
+            c.ref = xlnt::detail::Cell_Reference(row_arg, attr.second.value);
         }
         else if (string_equal(attr.first.name(), "t"))
         {
@@ -307,7 +248,7 @@ Cell parse_cell(xlnt::row_t row_arg, xml::parser *parser)
 }
 
 // <row> inside <sheetData> element
-std::pair<xlnt::row_properties, int> parse_row(xml::parser *parser, xlnt::detail::number_serialiser &converter, std::vector<Cell> &parsed_cells)
+std::pair<xlnt::row_properties, int> parse_row(xml::parser *parser, xlnt::detail::number_serialiser &converter, std::vector<xlnt::detail::Cell> &parsed_cells)
 {
     std::pair<xlnt::row_properties, int> props;
     for (auto &attr : parser->attribute_map())

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -251,7 +251,8 @@ Cell parse_cell(xlnt::row_t row_arg, xml::parser *parser)
     }
     int level = 1; // nesting level
         // 1 == <c>
-        // 2 == <v>/<is>/<f>
+        // 2 == <v>/<f>
+        // 3 == <is><t>
         // exit loop at </c>
     while (level > 0)
     {
@@ -272,7 +273,6 @@ Cell parse_cell(xlnt::row_t row_arg, xml::parser *parser)
             if (level == 2)
             {
                 // <v> -> numeric values
-                // <is><t> -> inline string
                 if (string_equal(parser->name(), "v"))
                 {
                     c.value += std::move(parser->value());

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2813,33 +2813,12 @@ void xlsx_producer::write_worksheet(const relationship &rel)
     {
         write_start_element(xmlns, "pageMargins");
 
-        // TODO: there must be a better way to do this
-        auto remove_trailing_zeros = [](const std::string &n) -> std::string {
-            auto decimal = n.find('.');
-
-            if (decimal == std::string::npos) return n;
-
-            auto index = n.size() - 1;
-
-            while (index >= decimal && n[index] == '0')
-            {
-                index--;
-            }
-
-            if (index == decimal)
-            {
-                return n.substr(0, decimal);
-            }
-
-            return n.substr(0, index + 1);
-        };
-
-        write_attribute("left", remove_trailing_zeros(std::to_string(ws.page_margins().left())));
-        write_attribute("right", remove_trailing_zeros(std::to_string(ws.page_margins().right())));
-        write_attribute("top", remove_trailing_zeros(std::to_string(ws.page_margins().top())));
-        write_attribute("bottom", remove_trailing_zeros(std::to_string(ws.page_margins().bottom())));
-        write_attribute("header", remove_trailing_zeros(std::to_string(ws.page_margins().header())));
-        write_attribute("footer", remove_trailing_zeros(std::to_string(ws.page_margins().footer())));
+        write_attribute("left", ws.page_margins().left());
+        write_attribute("right", ws.page_margins().right());
+        write_attribute("top", ws.page_margins().top());
+        write_attribute("bottom", ws.page_margins().bottom());
+        write_attribute("header", ws.page_margins().header());
+        write_attribute("footer", ws.page_margins().footer());
 
         write_end_element(xmlns, "pageMargins");
     }

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -40,7 +40,6 @@
 #include <detail/header_footer/header_footer_code.hpp>
 #include <detail/implementations/workbook_impl.hpp>
 #include <detail/serialization/custom_value_traits.hpp>
-#include <detail/serialization/serialisation_helpers.hpp>
 #include <detail/serialization/vector_streambuf.hpp>
 #include <detail/serialization/xlsx_producer.hpp>
 #include <detail/serialization/zstream.hpp>
@@ -2282,59 +2281,8 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         write_end_element(xmlns, "sheetPr");
     }
 
-    std::vector<const xlnt::detail::cell_impl*> cells;
-    std::vector<std::pair<row_t, row_properties>> row_props;
-    std::vector<std::pair<column_t::index_t, column_properties>> column_props;
-    // assume most of the cells are "live"
-    cells.reserve(ws.d_->cell_map_.size());
-    for (const auto &cell_impl : ws.d_->cell_map_)
-    {
-        // skip cells that aren't "live"
-        if (cell_impl.second.is_garbage_collectible())
-        {
-            continue;
-        }
-        cells.push_back(&cell_impl.second);
-    }
-    row_props.reserve(ws.d_->column_properties_.size());
-    for (const auto &row_prop : ws.d_->row_properties_)
-    {
-        row_props.push_back(row_prop);
-    }
-    column_props.reserve(ws.d_->column_properties_.size());
-    for (const auto &col_prop : ws.d_->column_properties_)
-    {
-        column_props.push_back(std::make_pair(col_prop.first.index, col_prop.second));
-    }
-    // sorting by location makes many following operations *much* faster
-    std::sort(cells.begin(), cells.end(), [](const cell_impl *l, const cell_impl *r) {
-        // row major sort
-        if (l->row_ < r->row_)
-        {
-            return true;
-        }
-        if (r->row_ < l->row_)
-        {
-            return false;
-        }
-        return l->column_ < r->column_;
-    });
-    std::sort(row_props.begin(), row_props.end(), [](const std::pair<row_t, row_properties> &l, const std::pair<row_t, row_properties> &r) { return l.first < r.first; });
-    std::sort(column_props.begin(), column_props.end(), [](const std::pair<column_t::index_t, column_properties> &l, const std::pair<column_t::index_t, column_properties> &r) { return l.first < r.first; });
-
     write_start_element(xmlns, "dimension");
-    // THIS IS WRONG. Needs to account for presence of row/column properties
-    // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_dimension_topic_ID0EZ2X4.html
-    const auto dimension = [&]() {
-        if (cells.empty())
-        {
-            return ws.calculate_dimension();
-        }
-        else
-        {
-            return xlnt::range_reference((*cells.begin())->column_, (*cells.begin())->row_, (*cells.rbegin())->column_, (*cells.rbegin())->row_);
-        }
-    }();
+    const auto dimension = ws.calculate_dimension();
     write_attribute("ref", dimension.is_single_cell() ? dimension.top_left().to_string() : dimension.to_string());
     write_end_element(xmlns, "dimension");
 
@@ -2448,38 +2396,57 @@ void xlsx_producer::write_worksheet(const relationship &rel)
 
     write_end_element(xmlns, "sheetFormatPr");
 
-    if (!column_props.empty())
-    {
-        write_start_element(xmlns, "cols");
-        for (const auto &props : column_props)
-        {
-            write_start_element(xmlns, "col");
-            write_attribute("min", props.first);
-            write_attribute("max", props.first);
+    bool has_column_properties = false;
+    const auto first_column = ws.lowest_column_or_props();
+    const auto last_column = ws.highest_column_or_props();
 
-            if (props.second.width.is_set())
-            {
-                double width = (props.second.width.get() * 7 + 5) / 7;
-                write_attribute("width", converter_.serialise(width));
-            }
-            if (props.second.best_fit)
-            {
-                write_attribute("bestFit", write_bool(true));
-            }
-            if (props.second.style.is_set())
-            {
-                write_attribute("style", props.second.style.get());
-            }
-            if (props.second.hidden)
-            {
-                write_attribute("hidden", write_bool(true));
-            }
-            if (props.second.custom_width)
-            {
-                write_attribute("customWidth", write_bool(true));
-            }
-            write_end_element(xmlns, "col");
+    for (auto column = first_column; column <= last_column; column++)
+    {
+        if (!ws.has_column_properties(column)) continue;
+
+        if (!has_column_properties)
+        {
+            write_start_element(xmlns, "cols");
+            has_column_properties = true;
         }
+
+        const auto &props = ws.column_properties(column);
+
+        write_start_element(xmlns, "col");
+        write_attribute("min", column.index);
+        write_attribute("max", column.index);
+
+        if (props.width.is_set())
+        {
+            double width = (props.width.get() * 7 + 5) / 7;
+            write_attribute("width", converter_.serialise(width));
+        }
+
+        if (props.best_fit)
+        {
+            write_attribute("bestFit", write_bool(true));
+        }
+
+        if (props.style.is_set())
+        {
+            write_attribute("style", props.style.get());
+        }
+
+        if (props.hidden)
+        {
+            write_attribute("hidden", write_bool(true));
+        }
+
+        if (props.custom_width)
+        {
+            write_attribute("customWidth", write_bool(true));
+        }
+
+        write_end_element(xmlns, "col");
+    }
+
+    if (has_column_properties)
+    {
         write_end_element(xmlns, "cols");
     }
 
@@ -2487,44 +2454,56 @@ void xlsx_producer::write_worksheet(const relationship &rel)
     std::vector<cell_reference> cells_with_comments;
 
     write_start_element(xmlns, "sheetData");
-
+    auto first_row = ws.lowest_row_or_props();
+    auto last_row = ws.highest_row_or_props();
     auto first_block_column = constants::max_column();
     auto last_block_column = constants::min_column();
 
-    auto current_cell = cells.begin();
-    auto current_row = row_props.begin();
-    row_t prev_row = 0; // constants::min_row() - 1
-    while (current_cell != cells.end() && current_row != row_props.end())
+    for (auto row = first_row; row <= last_row; ++row)
     {
-        auto row = [&]() {
-            row_t row_tmp = constants::max_row();
-            // we know atleast one of the following is valid
-            if (current_cell != cells.end())
-            {
-                row_tmp = (*current_cell)->row_;
-            }
-            if (current_row != row_props.end())
-            {
-                row_tmp = std::min(current_row->first, row_tmp);
-            }
-            return row_tmp;
-        }();
-        // true for the first row on/after 1, 17, 33, ... (16 * x + 1)
-        auto first_row_in_block = prev_row == 0 || ((row - 1) / 16) > ((prev_row - 1) / 16);
+        bool any_non_null = false;
+        auto first_check_row = row;
+        auto last_check_row = row;
+        auto first_row_in_block = row == first_row || row % 16 == 1;
+
         // See note for CT_Row, span attribute about block optimization
         if (first_row_in_block)
         {
             // reset block column range
-            first_block_column = constants::max_column().index;
-            last_block_column = constants::min_column().index;
+            first_block_column = constants::max_column();
+            last_block_column = constants::min_column();
+
+            first_check_row = row;
             // round up to the next multiple of 16
-            auto last_check_row = ((row / 16) + 1) * 16;
-            for (auto check_cell = current_cell; check_cell != cells.end() && (*check_cell)->row_ <= last_check_row; ++check_cell)
+            last_check_row = ((row / 16) + 1) * 16;
+        }
+
+        for (auto check_row = first_check_row; check_row <= last_check_row; ++check_row)
+        {
+            for (auto column = dimension.top_left().column(); column <= dimension.bottom_right().column(); ++column)
             {
-                first_block_column = std::min(first_block_column, (*check_cell)->column_);
-                last_block_column = std::max(last_block_column, (*check_cell)->column_);
+                auto ref = cell_reference(column, check_row);
+                auto cell = ws.d_->cell_map_.find(ref);
+                if (cell == ws.d_->cell_map_.end())
+                {
+                    continue;
+                }
+                if (cell->second.is_garbage_collectible())
+                {
+                    continue;
+                }
+
+                first_block_column = std::min(first_block_column, cell->second.column_);
+                last_block_column = std::max(last_block_column, cell->second.column_);
+
+                if (row == check_row)
+                {
+                    any_non_null = true;
+                }
             }
         }
+
+        if (!any_non_null && !ws.has_row_properties(row)) continue;
 
         write_start_element(xmlns, "row");
         write_attribute("r", row);
@@ -2532,10 +2511,11 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         auto span_string = std::to_string(first_block_column.index) + ":"
             + std::to_string(last_block_column.index);
         write_attribute("spans", span_string);
-        // write properties of this row if they exist
-        if (current_row != row_props.end() && current_row->first == row)
+
+        if (ws.has_row_properties(row))
         {
-            const auto &props = current_row->second;
+            const auto &props = ws.row_properties(row);
+
             if (props.style.is_set())
             {
                 write_attribute("s", props.style.get());
@@ -2544,140 +2524,152 @@ void xlsx_producer::write_worksheet(const relationship &rel)
             {
                 write_attribute("customFormat", write_bool(props.custom_format.get()));
             }
+
             if (props.height.is_set())
             {
                 auto height = props.height.get();
                 write_attribute("ht", converter_.serialise(height));
             }
+
             if (props.hidden)
             {
                 write_attribute("hidden", write_bool(true));
             }
+
             if (props.custom_height)
             {
                 write_attribute("customHeight", write_bool(true));
             }
+
             if (props.dy_descent.is_set())
             {
                 write_attribute(xml::qname(xmlns_x14ac, "dyDescent"), props.dy_descent.get());
             }
-            ++current_row;
         }
 
-        while (current_cell != cells.end() && (*current_cell)->row_ == row)
+        if (any_non_null)
         {
-            auto cell_ref = cell_reference((*current_cell)->column_, (*current_cell)->row_);
-            if ((*current_cell)->comment_.is_set())
+            for (auto column = dimension.top_left().column(); column <= dimension.bottom_right().column(); ++column)
             {
-                cells_with_comments.push_back(cell_ref);
+                if (!ws.has_cell(cell_reference(column, row))) continue;
+
+                auto cell = ws.cell(cell_reference(column, row));
+
+                if (cell.garbage_collectible()) continue;
+
+                // record data about the cell needed later
+
+                if (cell.has_comment())
+                {
+                    cells_with_comments.push_back(cell.reference());
+                }
+
+                if (cell.has_hyperlink())
+                {
+                    hyperlinks.push_back(std::make_pair(cell.reference().to_string(), cell.hyperlink()));
+                }
+
+                write_start_element(xmlns, "c");
+
+                // begin cell attributes
+
+                write_attribute("r", cell.reference().to_string());
+
+                if (cell.phonetics_visible())
+                {
+                    write_attribute("ph", write_bool(true));
+                }
+
+                if (cell.has_format())
+                {
+                    write_attribute("s", cell.format().d_->id);
+                }
+
+                switch (cell.data_type())
+                {
+                case cell::type::empty:
+                    break;
+
+                case cell::type::boolean:
+                    write_attribute("t", "b");
+                    break;
+
+                case cell::type::date:
+                    write_attribute("t", "d");
+                    break;
+
+                case cell::type::error:
+                    write_attribute("t", "e");
+                    break;
+
+                case cell::type::inline_string:
+                    write_attribute("t", "inlineStr");
+                    break;
+
+                case cell::type::number: // default, don't write it
+                    //write_attribute("t", "n");
+                    break;
+
+                case cell::type::shared_string:
+                    write_attribute("t", "s");
+                    break;
+
+                case cell::type::formula_string:
+                    write_attribute("t", "str");
+                    break;
+                }
+
+                //write_attribute("cm", "");
+                //write_attribute("vm", "");
+                //write_attribute("ph", "");
+
+                // begin child elements
+
+                if (cell.has_formula())
+                {
+                    write_element(xmlns, "f", cell.formula());
+                }
+
+                switch (cell.data_type())
+                {
+                case cell::type::empty:
+                    break;
+
+                case cell::type::boolean:
+                    write_element(xmlns, "v", write_bool(cell.value<bool>()));
+                    break;
+
+                case cell::type::date:
+                    write_element(xmlns, "v", cell.value<std::string>());
+                    break;
+
+                case cell::type::error:
+                    write_element(xmlns, "v", cell.value<std::string>());
+                    break;
+
+                case cell::type::inline_string:
+                    write_start_element(xmlns, "is");
+                    write_rich_text(xmlns, cell.value<xlnt::rich_text>());
+                    write_end_element(xmlns, "is");
+                    break;
+
+                case cell::type::number:
+                    write_start_element(xmlns, "v");
+                    write_characters(converter_.serialise(cell.value<double>()));
+                    write_end_element(xmlns, "v");
+                    break;
+
+                case cell::type::shared_string:
+                    write_element(xmlns, "v", static_cast<std::size_t>(cell.d_->value_numeric_));
+                    break;
+
+                case cell::type::formula_string:
+                    write_element(xmlns, "v", cell.value<std::string>());
+                    break;
+                }
+
+                write_end_element(xmlns, "c");
             }
-
-            if ((*current_cell)->hyperlink_.is_set())
-            {
-                // hyperlinks.push_back(std::make_pair(cell_ref.to_string(), xlnt::hyperlink(&current_cell->hyperlink_.get())));
-            }
-
-            write_start_element(xmlns, "c");
-
-            // begin cell attributes
-
-            write_attribute("r", cell_ref.to_string());
-
-            if ((*current_cell)->phonetics_visible_)
-            {
-                write_attribute("ph", write_bool(true));
-            }
-
-            if ((*current_cell)->format_.is_set())
-            {
-                write_attribute("s", (*current_cell)->format_.get()->id);
-            }
-
-            switch ((*current_cell)->type_)
-            {
-            case cell_type::empty:
-                break;
-
-            case cell_type::boolean:
-                write_attribute("t", "b");
-                break;
-
-            case cell_type::date:
-                write_attribute("t", "d");
-                break;
-
-            case cell_type::error:
-                write_attribute("t", "e");
-                break;
-
-            case cell_type::inline_string:
-                write_attribute("t", "inlineStr");
-                break;
-
-            case cell_type::number: // default, don't write it
-                //write_attribute("t", "n");
-                break;
-
-            case cell_type::shared_string:
-                write_attribute("t", "s");
-                break;
-
-            case cell_type::formula_string:
-                write_attribute("t", "str");
-                break;
-            }
-
-            //write_attribute("cm", "");
-            //write_attribute("vm", "");
-            //write_attribute("ph", "");
-
-            // begin child elements
-
-            if ((*current_cell)->formula_.is_set())
-            {
-                write_element(xmlns, "f", (*current_cell)->formula_.get());
-            }
-
-            switch ((*current_cell)->type_)
-            {
-            case cell::type::empty:
-                break;
-
-            case cell::type::boolean:
-                write_element(xmlns, "v", write_bool((*current_cell)->value_numeric_ != 0.0));
-                break;
-
-            case cell::type::date:
-                write_element(xmlns, "v", (*current_cell)->value_text_.plain_text());
-                break;
-
-            case cell::type::error:
-                write_element(xmlns, "v", (*current_cell)->value_text_.plain_text());
-                break;
-
-            case cell::type::inline_string:
-                write_start_element(xmlns, "is");
-                write_rich_text(xmlns, (*current_cell)->value_text_);
-                write_end_element(xmlns, "is");
-                break;
-
-            case cell::type::number:
-                write_start_element(xmlns, "v");
-                write_characters(converter_.serialise((*current_cell)->value_numeric_));
-                write_end_element(xmlns, "v");
-                break;
-
-            case cell::type::shared_string:
-                write_element(xmlns, "v", static_cast<std::size_t>((*current_cell)->value_numeric_));
-                break;
-
-            case cell::type::formula_string:
-                write_element(xmlns, "v", (*current_cell)->value_text_.plain_text());
-                break;
-            }
-
-            write_end_element(xmlns, "c");
-            ++current_cell;
         }
 
         write_end_element(xmlns, "row");
@@ -3077,7 +3069,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
             }
         }
     }
-} // namespace detail
+}
 
 // Sheet Relationship Target Parts
 

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -28,9 +28,9 @@
 #include <memory>
 #include <vector>
 
+#include <xlnt/utils/numeric.hpp>
 #include <detail/constants.hpp>
 #include <detail/external/include_libstudxml.hpp>
-#include <xlnt/utils/numeric.hpp>
 
 namespace xml {
 class serializer;
@@ -169,19 +169,34 @@ private:
 
     void write_namespace(const std::string &ns, const std::string &prefix);
 
-    template<typename T>
+    // std::string attribute name
+    // not integer or float type
+    template <typename T, typename = std::enable_if_t<!std::is_convertible_v<T, double>>>
     void write_attribute(const std::string &name, T value)
     {
         current_part_serializer_->attribute(name, value);
     }
 
-    template<typename T>
+    void write_attribute(const std::string &name, double value)
+    {
+        current_part_serializer_->attribute(name, converter_.serialise(value));
+    }
+
+    // qname attribute name
+    // not integer or float type
+    template <typename T, typename = std::enable_if_t<!std::is_convertible_v<T, double>>>
     void write_attribute(const xml::qname &name, T value)
     {
         current_part_serializer_->attribute(name, value);
     }
 
-    template<typename T>
+    void write_attribute(const xml::qname &name, double value)
+    {
+        current_part_serializer_->attribute(name, converter_.serialise(value));
+    }
+
+
+    template <typename T>
     void write_characters(T characters, bool preserve_whitespace = false)
     {
         if (preserve_whitespace)

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -172,7 +172,7 @@ private:
 
     // std::string attribute name
     // not integer or float type
-    template <typename T, typename = std::enable_if_t<!std::is_convertible_v<T, double>>>
+    template <typename T, typename = std::enable_if<!std::is_convertible_v<T, double>>::type>
     void write_attribute(const std::string &name, T value)
     {
         current_part_serializer_->attribute(name, value);
@@ -185,7 +185,7 @@ private:
 
     // qname attribute name
     // not integer or float type
-    template <typename T, typename = std::enable_if_t<!std::is_convertible_v<T, double>>>
+    template <typename T, typename = std::enable_if<!std::is_convertible_v<T, double>>::type>
     void write_attribute(const xml::qname &name, T value)
     {
         current_part_serializer_->attribute(name, value);

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include <xlnt/utils/numeric.hpp>

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -172,7 +172,7 @@ private:
 
     // std::string attribute name
     // not integer or float type
-    template <typename T, typename = std::enable_if<!std::is_convertible_v<T, double>>::type>
+    template <typename T, typename = std::enable_if<!std::is_convertible<T, double>::value>::type>
     void write_attribute(const std::string &name, T value)
     {
         current_part_serializer_->attribute(name, value);
@@ -185,7 +185,7 @@ private:
 
     // qname attribute name
     // not integer or float type
-    template <typename T, typename = std::enable_if<!std::is_convertible_v<T, double>>::type>
+    template <typename T, typename = std::enable_if<!std::is_convertible<T, double>::value>::type>
     void write_attribute(const xml::qname &name, T value)
     {
         current_part_serializer_->attribute(name, value);

--- a/source/detail/serialization/xlsx_producer.hpp
+++ b/source/detail/serialization/xlsx_producer.hpp
@@ -172,7 +172,7 @@ private:
 
     // std::string attribute name
     // not integer or float type
-    template <typename T, typename = std::enable_if<!std::is_convertible<T, double>::value>::type>
+    template <typename T, typename = typename std::enable_if<!std::is_convertible<T, double>::value>::type>
     void write_attribute(const std::string &name, T value)
     {
         current_part_serializer_->attribute(name, value);
@@ -185,7 +185,7 @@ private:
 
     // qname attribute name
     // not integer or float type
-    template <typename T, typename = std::enable_if<!std::is_convertible<T, double>::value>::type>
+    template <typename T, typename = typename std::enable_if<!std::is_convertible<T, double>::value>::type>
     void write_attribute(const xml::qname &name, T value)
     {
         current_part_serializer_->attribute(name, value);


### PR DESCRIPTION
Unlike recent PR's from me, this is almost entirely a correctness improvement.
With this branch, local runs of the test suite have no failures even when the locale is changed to one which uses the comma character as its decimal separator (i.e. passes with set_locale(LC_ALL, "de-DE") on windows. the german locale name may be different on other platforms)

This is done by removing all usages of the following functions when applied to floating point types (e.g. double) to convert them to a string representation
* std::stringstream
* std::to_string
* s*printf

Instead these number_serialiser::serialise and number_serialiser::serialise_short use the same technique of coverting the comma to a decimal point when required as was used in #421 to affect the reverse transformation (string->double)

I'm not sure of the best way to add a locale check to CI. Duplicating one of the round trip tests (all formats is probably the best one for this) and modifying the locale while it runs would work, but there's still the issue of different names on different platforms, and which (if any) alternative locales are installed by default

locale tests on windows can be affected by adding the following to the start of the test main
`setlocale(LC_ALL, "de-DE");`
default locale can be restored by putting "C" as the locale name