### PR TITLE
Fix XLNT_INCLUDE_INSTALL_DIR

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -256,6 +256,9 @@ install(EXPORT XlntTargets
 include(CMakePackageConfigHelpers)
 
 set(XLNT_INCLUDE_INSTALL_DIR ${XLNT_INC_DEST_DIR})
+if(CMAKE_INSTALL_PREFIX)
+  set(XLNT_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${XLNT_INCLUDE_INSTALL_DIR})
+endif()
 
 #See https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html
 configure_package_config_file(../cmake/XlntConfig.cmake.in


### PR DESCRIPTION
Otherwise, XLNT_INCLUDE_INSTALL_DIR is not set correctly and find_package(Xlnt) results to an error:
 ```
CMake Error at /usr/lib64/cmake/xlnt/XlntConfig.cmake:23 (message):
  File or directory include referenced by variable XLNT_INCLUDE_DIR does not
  exist !
Call Stack (most recent call first):
  /usr/lib64/cmake/xlnt/XlntConfig.cmake:41 (set_and_check)
  CMakeLists.txt:4 (find_package)
```
The content of the line 41 of /usr/lib64/cmake/xlnt/XlntConfig.cmake is: `set_and_check(XLNT_INCLUDE_DIR "include")`. 

I'm using the Arch Linux user repository package https://aur.archlinux.org/packages/xlnt/.
The used build manual is described here: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xlnt.