### PR TITLE
LibreOffice color names support

### DIFF
--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -1346,11 +1346,11 @@ format_color number_format_parser::color_from_string(const std::string &color)
     switch (color[0])
     {
     case 'C':
-        if (color == "Cyan")
+        if ((color == "Cyan") || (color == "CYAN"))
         {
             return format_color::cyan;
         }
-        else if (color.substr(0, 5) == "Color")
+        else if ((color.substr(0, 5) == "Color") || (color.substr(0, 5) == "COLOR"))
         {
             auto color_number = std::stoull(color.substr(5));
 
@@ -1364,11 +1364,11 @@ format_color number_format_parser::color_from_string(const std::string &color)
         break;
 
     case 'B':
-        if (color == "Black")
+        if ((color == "Black") || (color == "BLACK"))
         {
             return format_color::black;
         }
-        else if (color == "Blue")
+        else if ((color == "Blue") || (color == "BLUE"))
         {
             return format_color::blue;
         }
@@ -1377,7 +1377,7 @@ format_color number_format_parser::color_from_string(const std::string &color)
         break;
 
     case 'G':
-        if (color == "Green")
+        if ((color == "Green") || (color == "GREEN"))
         {
             return format_color::green;
         }
@@ -1386,7 +1386,7 @@ format_color number_format_parser::color_from_string(const std::string &color)
         break;
 
     case 'W':
-        if (color == "White")
+        if ((color == "White") || (color == "WHITE"))
         {
             return format_color::white;
         }
@@ -1395,7 +1395,7 @@ format_color number_format_parser::color_from_string(const std::string &color)
         break;
 
     case 'M':
-        if (color == "Magenta")
+        if ((color == "Magenta") || (color == "MAGENTA"))
         {
             return format_color::magenta;
         }
@@ -1404,7 +1404,7 @@ format_color number_format_parser::color_from_string(const std::string &color)
         break;
 
     case 'Y':
-        if (color == "Yellow")
+        if ((color == "Yellow") || (color == "YELLOW"))
         {
             return format_color::yellow;
         }
@@ -1413,7 +1413,7 @@ format_color number_format_parser::color_from_string(const std::string &color)
         break;
 
     case 'R':
-        if (color == "Red")
+        if ((color == "Red") || (color == "RED"))
         {
             return format_color::red;
         }


### PR DESCRIPTION
LibreOffice use color names in upper case. It is desirable to support this format