### PR TITLE
Fix - Print Settings (Page Size, margins, etc) not saved when loading a file and save it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ python/xlntpyarrow.egg-info/
 /x64/
 .envrc
 .vscode
+/.vs/
+/out/
+/CMakeSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ python/xlntpyarrow.egg-info/
 /x64/
 .envrc
 .vscode
+/dist/
 /.vs/
 /out/
 /CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(xlnt_all)
 
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 # CTest setup
 # include (CTest) # Add this for valgrind support; CTest works without it
 enable_testing()

--- a/include/xlnt/worksheet/page_setup.hpp
+++ b/include/xlnt/worksheet/page_setup.hpp
@@ -120,6 +120,11 @@ public:
     void paper_size(xlnt::paper_size paper_size);
 
     /// <summary>
+    /// Check if current paper setting has paper size setting
+    /// </summary>
+    bool has_paper_size() const;
+
+    /// <summary>
     /// Returns true if this worksheet should be scaled to fit on a single page during printing.
     /// </summary>
     bool fit_to_page() const;
@@ -160,6 +165,26 @@ public:
     double scale() const;
 
     /// <summary>
+    /// Check if current paper setting has scale setting
+    /// </summary>
+    bool has_scale() const;
+
+    /// <summary>
+    /// Gets reference relationship Id
+    /// </summary>
+    const std::string& rel_id() const;
+
+    /// <summary>
+    /// Sets reference relationship Id
+    /// </summary>
+    void rel_id(const std::string& val);
+
+    /// <summary>
+    /// Check if current paper setting has a reference relationship
+    /// </summary>
+    bool has_rel_id() const;
+
+    /// <summary>
     /// The orientation
     /// </summary>
     xlnt::optional<xlnt::orientation> orientation_;
@@ -176,6 +201,11 @@ public:
 
 private:
     /// <summary>
+    /// Relationship Id
+    /// </summary>
+    std::string rel_id_;
+
+    /// <summary>
     /// The break
     /// </summary>
     xlnt::page_break break_;
@@ -188,7 +218,7 @@ private:
     /// <summary>
     /// The paper size
     /// </summary>
-    xlnt::paper_size paper_size_;
+    xlnt::optional<xlnt::paper_size> paper_size_;
 
     /// <summary>
     /// Whether or not to fit to page
@@ -208,7 +238,7 @@ private:
     /// <summary>
     /// The amount to scale the worksheet
     /// </summary>
-    double scale_;
+    xlnt::optional<double> scale_;
 };
 
 } // namespace xlnt

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -955,19 +955,19 @@ worksheet xlsx_consumer::read_worksheet_end(const std::string &rel_id)
             }
             if (parser().attribute_present("gridLinesSet"))
             {
-                opts.print_grid_lines.set(parser().attribute<bool>("gridLinesSet"));
+                opts.grid_lines_set.set(parser().attribute<bool>("gridLinesSet"));
             }
             if (parser().attribute_present("headings"))
             {
-                opts.print_grid_lines.set(parser().attribute<bool>("headings"));
+                opts.print_headings.set(parser().attribute<bool>("headings"));
             }
             if (parser().attribute_present("horizontalCentered"))
             {
-                opts.print_grid_lines.set(parser().attribute<bool>("horizontalCentered"));
+                opts.horizontal_centered.set(parser().attribute<bool>("horizontalCentered"));
             }
             if (parser().attribute_present("verticalCentered"))
             {
-                opts.print_grid_lines.set(parser().attribute<bool>("verticalCentered"));
+                opts.vertical_centered.set(parser().attribute<bool>("verticalCentered"));
             }
             ws.d_->print_options_.set(opts);
             skip_remaining_content(current_worksheet_element);
@@ -999,6 +999,18 @@ worksheet xlsx_consumer::read_worksheet_end(const std::string &rel_id)
             if (parser().attribute_present("verticalDpi"))
             {
                 setup.vertical_dpi_.set(parser().attribute<std::size_t>("verticalDpi"));
+            }
+            if (parser().attribute_present("paperSize"))
+            {
+                setup.paper_size(static_cast<xlnt::paper_size>(parser().attribute<std::size_t>("paperSize")));
+            }
+            if (parser().attribute_present("scale"))
+            {
+                setup.scale(parser().attribute<double>("scale"));
+            }
+            if (parser().attribute_present(qn("r", "id")))
+            {
+                setup.rel_id(parser().attribute(qn("r", "id")));
             }
             ws.page_setup(setup);
             skip_remaining_content(current_worksheet_element);

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2782,6 +2782,22 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         write_end_element(xmlns, "hyperlinks");
     }
 
+    if (ws.has_phonetic_properties())
+    {
+        write_start_element(xmlns, phonetic_pr::Serialised_ID());
+        const auto &ph_props = ws.phonetic_properties();
+        write_attribute("fontId", ph_props.font_id());
+        if (ph_props.has_type())
+        {
+            write_attribute("type", phonetic_pr::type_as_string(ph_props.type()));
+        }
+        if (ph_props.has_alignment())
+        {
+            write_attribute("alignment", phonetic_pr::alignment_as_string(ph_props.alignment()));
+        }
+        write_end_element(xmlns, phonetic_pr::Serialised_ID());
+    }
+
     if (ws.d_->print_options_.is_set())
     {
         auto &opts = ws.d_->print_options_.get();
@@ -2809,22 +2825,6 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         write_end_element(xmlns, "printOptions");
     }
 
-    if (ws.has_phonetic_properties())
-    {
-        write_start_element(xmlns, phonetic_pr::Serialised_ID());
-        const auto &ph_props = ws.phonetic_properties();
-        write_attribute("fontId", ph_props.font_id());
-        if (ph_props.has_type())
-        {
-            write_attribute("type", phonetic_pr::type_as_string(ph_props.type()));
-        }
-        if (ph_props.has_alignment())
-        {
-            write_attribute("alignment", phonetic_pr::alignment_as_string(ph_props.alignment()));
-        }
-        write_end_element(xmlns, phonetic_pr::Serialised_ID());
-    }
-
     if (ws.has_page_margins())
     {
         write_start_element(xmlns, "pageMargins");
@@ -2841,6 +2841,7 @@ void xlsx_producer::write_worksheet(const relationship &rel)
 
     if (ws.has_page_setup())
     {
+        const xlnt::page_setup &ps = ws.page_setup();
         write_start_element(xmlns, "pageSetup");
         if (ws.page_setup().orientation_.is_set())
         {
@@ -2854,8 +2855,22 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         {
             write_attribute("verticalDpi", ws.page_setup().vertical_dpi_.get());
         }
-        /*write_attribute("paperSize", static_cast<std::size_t>(ws.page_setup().paper_size()));
-        write_attribute("fitToHeight", write_bool(ws.page_setup().fit_to_height()));
+        
+        if (ps.has_paper_size())
+        {
+            write_attribute("paperSize", static_cast<std::size_t>(ps.paper_size()));
+        }
+
+        if (ps.has_scale())
+        {
+            write_attribute("scale", ps.scale());
+        }
+
+        if (ps.has_rel_id())
+        {
+            write_attribute(xml::qname(xmlns_r, "id"), ps.rel_id());
+        }
+        /*write_attribute("fitToHeight", write_bool(ws.page_setup().fit_to_height()));
         write_attribute("fitToWidth", write_bool(ws.page_setup().fit_to_width()));*/
         write_end_element(xmlns, "pageSetup");
     }

--- a/source/worksheet/page_setup.cpp
+++ b/source/worksheet/page_setup.cpp
@@ -29,11 +29,9 @@ namespace xlnt {
 page_setup::page_setup()
     : break_(xlnt::page_break::none),
       sheet_state_(xlnt::sheet_state::visible),
-      paper_size_(xlnt::paper_size::letter),
       fit_to_page_(false),
       fit_to_height_(false),
-      fit_to_width_(false),
-      scale_(1)
+      fit_to_width_(false)
 {
 }
 

--- a/source/worksheet/page_setup.cpp
+++ b/source/worksheet/page_setup.cpp
@@ -59,12 +59,17 @@ void page_setup::sheet_state(xlnt::sheet_state sheet_state)
 
 paper_size page_setup::paper_size() const
 {
-    return paper_size_;
+    return paper_size_.get();
 }
 
 void page_setup::paper_size(xlnt::paper_size paper_size)
 {
     paper_size_ = paper_size;
+}
+
+bool page_setup::has_paper_size() const
+{
+    return this->paper_size_.is_set();
 }
 
 bool page_setup::fit_to_page() const
@@ -104,7 +109,27 @@ void page_setup::scale(double scale)
 
 double page_setup::scale() const
 {
-    return scale_;
+    return scale_.get();
+}
+
+bool page_setup::has_scale() const
+{
+    return this->scale_.is_set();
+}
+
+const std::string& page_setup::rel_id() const
+{
+    return this->rel_id_;
+}
+
+void page_setup::rel_id(const std::string& val)
+{
+    this->rel_id_ = val;
+}
+
+bool page_setup::has_rel_id() const
+{
+    return !rel_id_.empty();
 }
 
 bool page_setup::operator==(const page_setup &rhs) const
@@ -115,7 +140,9 @@ bool page_setup::operator==(const page_setup &rhs) const
         && fit_to_page_ == rhs.fit_to_page_
         && fit_to_height_ == rhs.fit_to_height_
         && fit_to_width_ == rhs.fit_to_width_
-        && detail::float_equals(scale_, rhs.scale_);
+        && scale_ == rhs.scale_
+        && paper_size_ == rhs.paper_size_
+        && rel_id_ == rhs.rel_id_;
 }
 
 } // namespace xlnt

--- a/tests/worksheet/page_setup_test_suite.cpp
+++ b/tests/worksheet/page_setup_test_suite.cpp
@@ -38,7 +38,7 @@ public:
     {
         xlnt::page_setup ps;
 
-        xlnt_assert_equals(ps.paper_size(), xlnt::paper_size::letter);
+        xlnt_assert(!ps.has_paper_size());
         ps.paper_size(xlnt::paper_size::executive);
         xlnt_assert_equals(ps.paper_size(), xlnt::paper_size::executive);
 


### PR DESCRIPTION
@tfussell Please check if you want to merge this change:

Fixing one issue - when loading an existing file as a template and save it, some print settings are lost.