### PR TITLE
The streaming cell now always begins with a clean state when using the xlnt::streaming_workbook_reader

### DIFF
--- a/source/cell/cell.cpp
+++ b/source/cell/cell.cpp
@@ -341,7 +341,10 @@ void cell::show_phonetics(bool phonetics)
 
 bool cell::is_date() const
 {
-    return data_type() == type::number
+    return (data_type() == type::number
+        || data_type() == type::shared_string
+        || data_type() == type::inline_string
+        || data_type() == cell_type::formula_string)
         && has_format()
         && number_format().is_date_format();
 }

--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -466,6 +466,8 @@ const std::unordered_map<int, std::string> known_locales()
             {0x7C68, "Hausa (Latin)"},
             {0x7C86, "K’iche’"},
             {0x7C92, "Central Kurdish (Arabic)"},
+            {0xF400, "System Default for Time"},
+            {0xF800, "System Default for Long Date"},
         });
 
     return all;

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -1322,6 +1322,7 @@ bool xlsx_consumer::has_cell()
     expect_start_element(qn("spreadsheetml", "c"), xml::content::complex);
 
     assert(streaming_);
+    streaming_cell_.reset(new detail::cell_impl()); // Clean cell state - otherwise it might contain information from the previously streamed cell.
     auto cell = xlnt::cell(streaming_cell_.get());
     auto reference = cell_reference(parser().attribute("r"));
     cell.d_->parent_ = current_worksheet_;


### PR DESCRIPTION
Example of XML code from an Excel sheet:

```
<c r="G4" s="5" t="s">
	<v>45</v>
</c>
<c r="H4"/>
<c r="I4" s="1">
	<v>3</v>
</c>
```

When using the xlnt::streaming_workbook_reader, the streaming_cell_ was previously reused, but was overwritten with information from the new cell. In the example above, reading cell G4 would read a shared_string at index 45. Cell H4 is a cell with no information except its reference, and would previously cause XLNT to return cell H4 with the information from cell G4.

The simple fix I provided resets the cell state, so that the streaming cell always begins with a clean state, just as it happens when not streaming.