### PR TITLE
Added support for the System Default locale for the Time and Long Date types

### DIFF
--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -466,6 +466,8 @@ const std::unordered_map<int, std::string> known_locales()
             {0x7C68, "Hausa (Latin)"},
             {0x7C86, "K’iche’"},
             {0x7C92, "Central Kurdish (Arabic)"},
+            {0xF400, "System Default for Time"},
+            {0xF800, "System Default for Long Date"},
         });
 
     return all;

--- a/source/detail/number_format/number_formatter.hpp
+++ b/source/detail/number_format/number_formatter.hpp
@@ -530,7 +530,9 @@ enum class format_locale
     tamazight_latin = 0x7C5F,
     fulah_latin = 0x7C67,
     hausa_latin = 0x7C68,
-    central_kurdish_arabic = 0x7C92
+    central_kurdish_arabic = 0x7C92,
+    system_default_time = 0xF400,
+    system_default_long_date = 0xF800
 };
 
 // TODO this really shouldn't be exported...


### PR DESCRIPTION
Explanation: https://bz.apache.org/ooo/show_bug.cgi?id=70003

This fixes issues with some locales where "system default" is the default setting for times and dates. This happens, for example, when using German (Austria) as a locale in Windows, or when setting it manually in Excel.

Especially when languages such as German (Austria) are used, where the "system default" is used for such types, the user is not aware of the locale and the probability of creating an Excel file that cannot be loaded by XLNT is very high.

This pull request fixes this issue.