### PR TITLE
cell::is_date() now correctly works for dates

### DIFF
--- a/source/cell/cell.cpp
+++ b/source/cell/cell.cpp
@@ -341,7 +341,10 @@ void cell::show_phonetics(bool phonetics)
 
 bool cell::is_date() const
 {
-    return data_type() == type::number
+    return (data_type() == type::number
+        || data_type() == type::shared_string
+        || data_type() == type::inline_string
+        || data_type() == cell_type::formula_string)
         && has_format()
         && number_format().is_date_format();
 }


### PR DESCRIPTION
cell::is_date() only worked correctly for times (saved in Excel as numbers), but not for dates (saved in Excel as strings - usually shared_strings). This pull request only adds a few more allowed types for dates, as all the other checks such as is_date_format() already exist and work very well.