### PR TITLE
Missing include in number_formatter.cpp

### DIFF
--- a/source/detail/number_format/number_formatter.cpp
+++ b/source/detail/number_format/number_formatter.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <limits>
 
 #include <xlnt/utils/exceptions.hpp>
 #include <xlnt/utils/numeric.hpp>


### PR DESCRIPTION
Limits isn't being transitively included on gcc 11.2.0/ubuntu.  Added as it produces an error