### PR TITLE
Fix format::number_format

### DIFF
--- a/source/styles/format.cpp
+++ b/source/styles/format.cpp
@@ -124,13 +124,28 @@ format format::font(const xlnt::font &new_font, optional<bool> applied)
 
 xlnt::number_format format::number_format() const
 {
-    if (number_format::is_builtin_format(d_->number_format_id.get()))
+    if (d_->number_format_id.is_set())
     {
-        return number_format::from_builtin_id(d_->number_format_id.get());
+        const auto number_format_id = d_->number_format_id.get();
+
+        if (number_format::is_builtin_format(number_format_id))
+        {
+            return number_format::from_builtin_id(number_format_id);
+        }
+
+        const auto it = std::find_if(d_->parent->number_formats.begin(),
+                                     d_->parent->number_formats.end(),
+                                     [number_format_id](const xlnt::number_format &nf)
+                                     {
+                                         return nf.id() == number_format_id;
+                                     });
+        if (it != d_->parent->number_formats.end())
+        {
+            return *it;
+        }
     }
 
-    return *std::find_if(d_->parent->number_formats.begin(), d_->parent->number_formats.end(),
-        [&](const xlnt::number_format nf) { return nf.id() == d_->number_format_id.get(); });
+    return xlnt::number_format();
 }
 
 format format::number_format(const xlnt::number_format &new_number_format, optional<bool> applied)


### PR DESCRIPTION
In case number_format() is called on a format that does not have a value format set, number_format() calls d_->number_format_id.get() on an invalid number_format_id or dereferences d_->parent->number_formats.end() causing a crash.

This can happen when calling cell::is_date() on a cell that has type 'number' without a number format but some other styling set.
This might never occur in spreadsheet files created by commercial applications but xlnt certainly allows to create such a file.
We therefore fix number_format by returning the general number format as a fallback.
Additionally, consider to add a method format::has_number_format() and change cell::is_date() accordingly.

Attached there is a test file were the problem occurs when cell::is_date() is called on cell A1.
[Test.xlsx](https://github.com/tfussell/xlnt/files/8661633/Test.xlsx)