### PR TITLE
fix writing of missing showGridLines attribute to xlsx file

### DIFF
--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2310,6 +2310,8 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         const auto wb_view = source_.view();
         const auto view = ws.view();
 
+        write_attribute("showGridLines", write_bool(view.show_grid_lines()));
+
         if ((wb_view.active_tab.is_set() && (ws.id() - 1) == wb_view.active_tab.get())
             || (!wb_view.active_tab.is_set() && ws.id() == 1))
         {

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -2310,7 +2310,10 @@ void xlsx_producer::write_worksheet(const relationship &rel)
         const auto wb_view = source_.view();
         const auto view = ws.view();
 
-        write_attribute("showGridLines", write_bool(view.show_grid_lines()));
+        if (!view.show_grid_lines())
+        {
+            write_attribute("showGridLines", write_bool(view.show_grid_lines()));
+        }
 
         if ((wb_view.active_tab.is_set() && (ws.id() - 1) == wb_view.active_tab.get())
             || (!wb_view.active_tab.is_set() && ws.id() == 1))


### PR DESCRIPTION
Very minor fix to xlsx_producer.cpp to add the already existing attribute to the xlsx file when it is being generated.
