### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Documentation for the current release of xlnt is available [here](https://tfusse
 
 ## Building xlnt - Using vcpkg
 
-You can download and install xlnt using the [vcpkg](https://github.com/Mixlntosoft/vcpkg) dependency manager:
+You can download and install xlnt using the [vcpkg](https://github.com/microsoft/vcpkg) dependency manager:
 
-    git clone https://github.com/Mixlntosoft/vcpkg.git
+    git clone https://github.com/microsoft/vcpkg.git
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
     ./vcpkg install xlnt
 
-The xlnt port in vcpkg is kept up to date by Mixlntosoft team members and community contributors. If the version is out of date, please [xlnteate an issue or pull request](https://github.com/Mixlntosoft/vcpkg) on the vcpkg repository.
+The xlnt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/microsoft/vcpkg) on the vcpkg repository.
 
 ## License
 xlnt is released to the public for free under the terms of the MIT License. See [LICENSE.md](https://github.com/tfussell/xlnt/blob/master/LICENSE.md) for the full text of the license and the licenses of xlnt's third-party dependencies. [LICENSE.md](https://github.com/tfussell/xlnt/blob/master/LICENSE.md) should be distributed alongside any assemblies that use xlnt in source or compiled form.

--- a/README.md
+++ b/README.md
@@ -36,5 +36,17 @@ int main()
 
 Documentation for the current release of xlnt is available [here](https://tfussell.gitbooks.io/xlnt/content/).
 
+## Building xlnt - Using vcpkg
+
+You can download and install xlnt using the [vcpkg](https://github.com/Mixlntosoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Mixlntosoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install xlnt
+
+The xlnt port in vcpkg is kept up to date by Mixlntosoft team members and community contributors. If the version is out of date, please [xlnteate an issue or pull request](https://github.com/Mixlntosoft/vcpkg) on the vcpkg repository.
+
 ## License
 xlnt is released to the public for free under the terms of the MIT License. See [LICENSE.md](https://github.com/tfussell/xlnt/blob/master/LICENSE.md) for the full text of the license and the licenses of xlnt's third-party dependencies. [LICENSE.md](https://github.com/tfussell/xlnt/blob/master/LICENSE.md) should be distributed alongside any assemblies that use xlnt in source or compiled form.


### PR DESCRIPTION
xlnt is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for xlnt and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build xlnt, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port sxlntipt looks like](https://github.com/microsoft/vcpkg/blob/e8bbe813151e45077fa70887b1f87ccce514701a/ports/xlnt/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)