### PR TITLE
Improving memory usage and allocation

### DIFF
--- a/source/detail/implementations/cell_impl.cpp
+++ b/source/detail/implementations/cell_impl.cpp
@@ -36,7 +36,9 @@ cell_impl::cell_impl()
       row_(1),
       is_merged_(false),
       phonetics_visible_(false),
-      value_numeric_(0)
+      value_numeric_(0),
+      format_(),
+	  comment_()
 {
 }
 

--- a/source/detail/implementations/cell_impl.hpp
+++ b/source/detail/implementations/cell_impl.hpp
@@ -58,17 +58,17 @@ struct cell_impl
     bool is_merged_;
     bool phonetics_visible_;
 
-    rich_text value_text_;
+    optional<rich_text> value_text_;
     double value_numeric_;
 
     optional<std::string> formula_;
     optional<hyperlink_impl> hyperlink_;
-    optional<format_impl *> format_;
-    optional<comment *> comment_;
+    format_impl *format_;
+	comment *comment_;
 
     bool is_garbage_collectible() const
     {
-        return !(type_ != cell_type::empty || is_merged_ || phonetics_visible_ || formula_.is_set() || format_.is_set() || hyperlink_.is_set());
+        return !(type_ != cell_type::empty || is_merged_ || phonetics_visible_ || formula_.is_set() || format_ != nullptr || hyperlink_.is_set());
     }
 };
 
@@ -84,8 +84,8 @@ inline bool operator==(const cell_impl &lhs, const cell_impl &rhs)
         && float_equals(lhs.value_numeric_, rhs.value_numeric_)
         && lhs.formula_ == rhs.formula_
         && lhs.hyperlink_ == rhs.hyperlink_
-        && (lhs.format_.is_set() == rhs.format_.is_set() && (!lhs.format_.is_set() || *lhs.format_.get() == *rhs.format_.get()))
-        && (lhs.comment_.is_set() == rhs.comment_.is_set() && (!lhs.comment_.is_set() || *lhs.comment_.get() == *rhs.comment_.get()));
+		&& ((lhs.format_ != nullptr) == (rhs.format_ != nullptr) && ((lhs.format_ == nullptr) || *lhs.format_ == *rhs.format_))
+        && ((lhs.comment_ != nullptr) == (rhs.comment_ != nullptr) && ((lhs.comment_ == nullptr) || *lhs.comment_ == *rhs.comment_));
 }
 
 } // namespace detail


### PR DESCRIPTION
Improving memory usage and allocation, as discussed in issue #648.
No need for an optional to a pointer
Switching to a pointer directly
Making value_text_ as optional to reduce memory usage