### PR TITLE
Add static keyword

### DIFF
--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -449,7 +449,7 @@ void xlsx_consumer::read_worksheet(const std::string &rel_id)
     }
 }
 
-void read_defined_names(worksheet ws, std::vector<defined_name> defined_names)
+static void read_defined_names(worksheet ws, std::vector<defined_name> defined_names)
 {
     for (auto &name : defined_names)
     {


### PR DESCRIPTION
Mark `xlnt::detail::read_defined_names()` as static as it is not supposed to be used outside this translation unit.