### PR TITLE
Update definedNames

### DIFF
--- a/source/detail/implementations/workbook_impl.hpp
+++ b/source/detail/implementations/workbook_impl.hpp
@@ -29,6 +29,7 @@
 
 #include <detail/implementations/stylesheet.hpp>
 #include <detail/implementations/worksheet_impl.hpp>
+#include <detail/serialization/defined_name.hpp>
 #include <xlnt/packaging/ext_list.hpp>
 #include <xlnt/packaging/manifest.hpp>
 #include <xlnt/utils/datetime.hpp>
@@ -88,11 +89,20 @@ struct workbook_impl
         extended_properties_ = other.extended_properties_;
         custom_properties_ = other.custom_properties_;
 
+        defined_names_ = other.defined_names_;
+
         return *this;
     }
 
     bool operator==(const workbook_impl &other)
     {
+        if (defined_names_.size() != other.defined_names_.size()) return false;
+
+        for (std::size_t i = 0; i < defined_names_.size(); i++)
+        {
+            if (defined_names_[i] != other.defined_names_[i]) return false;
+        }
+
         return active_sheet_index_ == other.active_sheet_index_
             && worksheets_ == other.worksheets_
             && shared_strings_ids_ == other.shared_strings_ids_
@@ -168,6 +178,7 @@ struct workbook_impl
     optional<std::string> abs_path_;
     optional<std::size_t> arch_id_flags_;
     optional<ext_list> extensions_;
+    std::vector<defined_name> defined_names_;
 };
 
 } // namespace detail

--- a/source/detail/serialization/defined_name.hpp
+++ b/source/detail/serialization/defined_name.hpp
@@ -30,9 +30,18 @@ namespace detail {
 
 struct defined_name
 {
+    // Implements (most of) CT_RevisionDefinedName, there's several "old" members in the spec but they're also ignored in other librarie
     std::string name;
-    std::size_t sheet_id;
-    bool hidden;
+    xlnt::optional<std::string> comment;
+    xlnt::optional<std::string> custom_menu;
+    xlnt::optional<std::string> description;
+    xlnt::optional<std::string> help;
+    xlnt::optional<std::string> status_bar;
+    xlnt::optional<std::size_t> sheet_id; // 0 indexed.
+    xlnt::optional<bool> hidden;
+    xlnt::optional<bool> function;
+    xlnt::optional<std::size_t> function_group_id;
+    xlnt::optional<std::string> shortcut_key; // This is unsigned byte in the spec, but openpyxl uses string so let's try that
     std::string value;
 };
 

--- a/source/detail/serialization/defined_name.hpp
+++ b/source/detail/serialization/defined_name.hpp
@@ -30,19 +30,62 @@ namespace detail {
 
 struct defined_name
 {
+
+    defined_name &operator=(const defined_name &other)
+    {
+        name = other.name;
+        comment = other.comment;
+        custom_menu = other.custom_menu;
+        description = other.description;
+        help = other.help;
+
+        status_bar = other.status_bar;
+        sheet_id = other.sheet_id;
+        hidden = other.hidden;
+        function = other.function;
+        function_group_id = other.function_group_id;
+
+        shortcut_key = other.shortcut_key;
+        value = other.value;
+
+        return *this;
+    }
+
+    bool operator==(const defined_name &other)
+    {
+        return name == other.name
+            && comment == other.comment
+            && custom_menu == other.custom_menu
+            && description == other.description
+            && help == other.help
+            && status_bar == other.status_bar
+            && sheet_id == other.sheet_id
+            && hidden == other.hidden
+            && function == other.function
+            && function_group_id == other.function_group_id
+            && shortcut_key == other.shortcut_key
+            && value == other.value;
+    }
+    bool operator!=(const defined_name &other)
+    {
+        return !(*this == other);
+    }
+
     // Implements (most of) CT_RevisionDefinedName, there's several "old" members in the spec but they're also ignored in other librarie
     std::string name;
-    xlnt::optional<std::string> comment;
-    xlnt::optional<std::string> custom_menu;
-    xlnt::optional<std::string> description;
-    xlnt::optional<std::string> help;
-    xlnt::optional<std::string> status_bar;
-    xlnt::optional<std::size_t> sheet_id; // 0 indexed.
-    xlnt::optional<bool> hidden;
-    xlnt::optional<bool> function;
-    xlnt::optional<std::size_t> function_group_id;
-    xlnt::optional<std::string> shortcut_key; // This is unsigned byte in the spec, but openpyxl uses string so let's try that
+    optional<std::string> comment;
+    optional<std::string> custom_menu;
+    optional<std::string> description;
+    optional<std::string> help;
+    optional<std::string> status_bar;
+    optional<std::size_t> sheet_id; // 0 indexed.
+    optional<bool> hidden;
+    optional<bool> function;
+    optional<std::size_t> function_group_id;
+    optional<std::string> shortcut_key; // This is unsigned byte in the spec, but openpyxl uses string so let's try that
     std::string value;
+
+    
 };
 
 } // namespace detail

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -2135,8 +2135,8 @@ void xlsx_consumer::read_office_document(const std::string &content_type) // CT_
 
                 parser().attribute_map(); // skip remaining attributes
                 name.value = read_text();
-                defined_names_.push_back(name);
-                
+                target_.d_->defined_names_.push_back(name);
+
                 expect_end_element(qn("spreadsheetml", "definedName"));
             }
         }

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -2082,12 +2082,57 @@ void xlsx_consumer::read_office_document(const std::string &content_type) // CT_
 
                 defined_name name;
                 name.name = parser().attribute("name");
-                name.sheet_id = parser().attribute<std::size_t>("localSheetId");
-                name.hidden = false;
+
+                if (parser().attribute_present("comment"))
+                {
+                    name.comment = parser().attribute<std::string>("comment");
+                }
+
+                if (parser().attribute_present("customMenu"))
+                {
+                    name.custom_menu = parser().attribute<std::string>("customMenu");
+                }
+
+                if (parser().attribute_present("description"))
+                {
+                    name.description = parser().attribute<std::string>("description");
+                }
+
+                if (parser().attribute_present("help"))
+                {
+                    name.help = parser().attribute<std::string>("help");
+                }
+
+                if (parser().attribute_present("statusBar"))
+                {
+                    name.status_bar = parser().attribute<std::string>("statusBar");
+                }
+
+                if (parser().attribute_present("localSheetId"))
+                {
+                    name.sheet_id = parser().attribute<std::size_t>("localSheetId");
+                }
+                
                 if (parser().attribute_present("hidden"))
                 {
                     name.hidden = is_true(parser().attribute("hidden"));
                 }
+
+                if (parser().attribute_present("function"))
+                {
+                    name.function = is_true(parser().attribute("function"));
+                }
+
+                if (parser().attribute_present("functionGroupId"))
+                {
+                    name.function_group_id = parser().attribute<std::size_t>("functionGroupId");
+                }
+
+                if (parser().attribute_present("shortcutKey"))
+                {
+                    name.shortcut_key = parser().attribute<std::string>("shortcutKey");
+                }
+
                 parser().attribute_map(); // skip remaining attributes
                 name.value = read_text();
                 defined_names_.push_back(name);

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -664,11 +664,67 @@ void xlsx_producer::write_workbook(const relationship &rel)
         {
             write_start_element(xmlns, "definedName");
             write_attribute("name", name.name);
-            if (name.hidden)
+
+            if (name.comment.is_set())
             {
-                write_attribute("hidden", write_bool(true));
+                write_attribute("comment", name.comment.get());
             }
-            write_attribute("localSheetId", std::to_string(name.sheet_id - 1)); // 0-indexed for some reason
+
+            if (name.custom_menu.is_set())
+            {
+                write_attribute("customMenu", name.custom_menu.get());
+            }
+
+            if (name.description.is_set())
+            {
+                write_attribute("description", name.description.get());
+            }
+
+            if (name.help.is_set())
+            {
+                write_attribute("help", name.help.get());
+            }
+
+            if (name.status_bar.is_set())
+            {
+                write_attribute("statusBar", name.status_bar.get());
+            }
+
+            if (name.sheet_id.is_set())
+            {
+                const auto sheet_id = name.sheet_id.get();
+                write_attribute("localSheetId", std::to_string(sheet_id - 1)); // Don't think this is meant to require subtracting 1?
+            }
+
+            if (name.hidden.is_set())
+            {
+                const auto hidden_state = name.hidden.get();
+                if (hidden_state)
+                {
+                    write_attribute("hidden", write_bool(true));
+                }
+            }
+
+            if (name.function.is_set())
+            {
+                const auto function_state = name.function.get();
+                if (function_state)
+                {
+                    write_attribute("function", write_bool(true));
+                }
+            }
+
+            if (name.function_group_id.is_set())
+            {
+                const auto function_group_id = name.function_group_id.get();
+                write_attribute("functionGroupId", std::to_string(function_group_id));
+            }
+
+            if (name.shortcut_key.is_set())
+            {
+                write_attribute("shortcutKey", name.shortcut_key.get());
+            }
+
             write_characters(name.value);
             write_end_element(xmlns, "definedName");
         }


### PR DESCRIPTION
Defined names are currently partially implemented (in regards to the spec and reading/writing). This PR should bring them more into line with the spec https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.revisiondefinedname?view=openxml-2.8.1

Still to do:
* Parsed names that are scoped to a worksheet should be a member of that sheet rather than the book
* Add functions to create/delete/modify defined names on workbook/worksheet
* Add/fix tests