### PR TITLE
Fix segmentation fault error on canonicalize manifest.cpp method

### DIFF
--- a/source/packaging/manifest.cpp
+++ b/source/packaging/manifest.cpp
@@ -61,7 +61,11 @@ path manifest::canonicalize(const std::vector<xlnt::relationship> &rels) const
 
         if (component == "..")
         {
-            absolute_parts.pop_back();
+            if (absolute_parts.size() > 0)
+            {
+                absolute_parts.pop_back();
+            }
+
             continue;
         }
 


### PR DESCRIPTION
As the linked issue says, the library segfaults when the relative path starts with `..` since it tries to `pop_back` an empty vector

Fix #683 