### PR TITLE
fix <cstdint> header miss

### DIFF
--- a/include/xlnt/cell/phonetic_run.hpp
+++ b/include/xlnt/cell/phonetic_run.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 

--- a/source/utils/time.cpp
+++ b/source/utils/time.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/time.hpp>
 

--- a/source/utils/timedelta.cpp
+++ b/source/utils/timedelta.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/timedelta.hpp>
 

--- a/source/utils/variant.cpp
+++ b/source/utils/variant.cpp
@@ -20,6 +20,7 @@
 //
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
+#include <cstdint>
 
 #include <xlnt/utils/datetime.hpp>
 #include <xlnt/utils/variant.hpp>


### PR DESCRIPTION
, which may cause compile errors under new version of libstdc++