### PR TITLE
Fixed compilation failure on gcc 13, added includes, tests fine

### DIFF
--- a/include/xlnt/cell/phonetic_run.hpp
+++ b/include/xlnt/cell/phonetic_run.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 
@@ -35,8 +36,8 @@ namespace xlnt {
 struct XLNT_API phonetic_run
 {
     std::string text;
-    uint32_t start;
-    uint32_t end;
+    std::uint32_t start;
+    std::uint32_t end;
     bool preserve_space;
 
     bool operator==(const phonetic_run &other) const;

--- a/include/xlnt/utils/variant.hpp
+++ b/include/xlnt/utils/variant.hpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 

--- a/include/xlnt/worksheet/worksheet.hpp
+++ b/include/xlnt/worksheet/worksheet.hpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/cell/index_types.hpp>

--- a/python/xlntpyarrow.lib.cpp
+++ b/python/xlntpyarrow.lib.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 
 #include <exception>
+#include <cstdint>
 #include <arrow/api.h>
 #include <arrow/python/pyarrow.h>
 #include <pybind11/pybind11.h>

--- a/source/detail/cryptography/aes.cpp
+++ b/source/detail/cryptography/aes.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/source/detail/cryptography/compound_document.cpp
+++ b/source/detail/cryptography/compound_document.cpp
@@ -29,6 +29,7 @@
 #include <locale>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <xlnt/utils/exceptions.hpp>
 #include <detail/binary.hpp>

--- a/source/detail/cryptography/compound_document.hpp
+++ b/source/detail/cryptography/compound_document.hpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 #include <detail/binary.hpp>
 #include <detail/unicode.hpp>

--- a/source/detail/cryptography/encryption_info.cpp
+++ b/source/detail/cryptography/encryption_info.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 
 #include <array>
+#include <cstdint>
 
 #include <detail/binary.hpp>
 #include <detail/cryptography/aes.hpp>

--- a/source/detail/cryptography/sha.cpp
+++ b/source/detail/cryptography/sha.cpp
@@ -27,6 +27,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 #include <detail/cryptography/sha.hpp>
 

--- a/source/detail/cryptography/xlsx_crypto_producer.cpp
+++ b/source/detail/cryptography/xlsx_crypto_producer.cpp
@@ -21,6 +21,8 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
+#include <cstdint>
+
 #include <xlnt/utils/exceptions.hpp>
 #include <detail/constants.hpp>
 #include <detail/cryptography/aes.hpp>

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -26,6 +26,7 @@
 #include <numeric> // for std::accumulate
 #include <sstream>
 #include <unordered_map>
+#include <cstdint>
 
 #include <xlnt/cell/cell.hpp>
 #include <xlnt/cell/comment.hpp>

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_set>
+#include <cstdint>
 
 #include <xlnt/cell/cell.hpp>
 #include <xlnt/cell/hyperlink.hpp>

--- a/source/detail/serialization/zstream.cpp
+++ b/source/detail/serialization/zstream.cpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <iterator> // for std::back_inserter
 #include <stdexcept>
 #include <string>
+#include <cstdint>
 #include <miniz.h>
 
 #include <xlnt/utils/exceptions.hpp>

--- a/source/detail/serialization/zstream.hpp
+++ b/source/detail/serialization/zstream.hpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <memory>
 #include <unordered_map>
 #include <vector>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 #include <xlnt/utils/path.hpp>

--- a/source/utils/time.cpp
+++ b/source/utils/time.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/time.hpp>
 

--- a/source/utils/timedelta.cpp
+++ b/source/utils/timedelta.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/timedelta.hpp>
 

--- a/source/utils/variant.cpp
+++ b/source/utils/variant.cpp
@@ -21,6 +21,8 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
+#include <cstdint>
+
 #include <xlnt/utils/datetime.hpp>
 #include <xlnt/utils/variant.hpp>
 
@@ -42,7 +44,7 @@ variant::variant(const char *value)
 {
 }
 
-variant::variant(int32_t value)
+variant::variant(std::int32_t value)
     : type_(type::i4),
       i4_value_(value)
 {

--- a/source/worksheet/worksheet.cpp
+++ b/source/worksheet/worksheet.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <cstdint>
 
 #include <xlnt/cell/cell.hpp>
 #include <xlnt/cell/cell_reference.hpp>

--- a/tests/utils/variant_tests.cpp
+++ b/tests/utils/variant_tests.cpp
@@ -21,6 +21,8 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 
+#include <cstdint>
+
 #include <xlnt/utils/variant.hpp>
 #include <helpers/test_suite.hpp>
 


### PR DESCRIPTION
This Pull Requests fixes the compilation failures on gcc 13 (g++) on Linux. I've added the includes where the numerics where used. The tests built fine and executed without errors:
```
xxxx> ./xlnt.test 
..........................................................................................................................................................................................................................................................................................................................

Run: 314
Passed: 314
Failed: 0
```

Superseeds #708 and #704 because I've looked at all the files and executed the test suite and PR authors don't respond.