### PR TITLE
fix uint32_t

### DIFF
--- a/include/xlnt/cell/phonetic_run.hpp
+++ b/include/xlnt/cell/phonetic_run.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 

--- a/include/xlnt/utils/variant.hpp
+++ b/include/xlnt/utils/variant.hpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 

--- a/source/utils/time.cpp
+++ b/source/utils/time.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/time.hpp>
 

--- a/source/utils/timedelta.cpp
+++ b/source/utils/timedelta.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/timedelta.hpp>
 


### PR DESCRIPTION
uint32_t needs header <cstdint>, at least for g++ on fedora