### PR TITLE
Add include <cstdint> to fix uint32_t etc.

### DIFF
--- a/include/xlnt/cell/phonetic_run.hpp
+++ b/include/xlnt/cell/phonetic_run.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 

--- a/include/xlnt/utils/variant.hpp
+++ b/include/xlnt/utils/variant.hpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <xlnt/xlnt_config.hpp>
 

--- a/source/detail/serialization/defined_name.hpp
+++ b/source/detail/serialization/defined_name.hpp
@@ -31,8 +31,13 @@ namespace detail {
 struct defined_name
 {
     std::string name;
+
+    // Replace this with std::optional as soon as xlnt is upgraded to C++17.
+    bool has_sheet_id;
     std::size_t sheet_id;
+
     bool hidden;
+
     std::string value;
 };
 

--- a/source/detail/serialization/xlsx_consumer.cpp
+++ b/source/detail/serialization/xlsx_consumer.cpp
@@ -453,7 +453,8 @@ void read_defined_names(worksheet ws, std::vector<defined_name> defined_names)
 {
     for (auto &name : defined_names)
     {
-        if (name.sheet_id != ws.id() - 1)
+        // Ignore all defined names that do not have the worksheet ID explicitly set.
+        if (!name.has_sheet_id || name.sheet_id != ws.id() - 1)
         {
             continue;
         }
@@ -2082,7 +2083,11 @@ void xlsx_consumer::read_office_document(const std::string &content_type) // CT_
 
                 defined_name name;
                 name.name = parser().attribute("name");
-                name.sheet_id = parser().attribute<std::size_t>("localSheetId");
+                name.has_sheet_id = parser().attribute_present("localSheetId");
+                if (name.has_sheet_id)
+                {
+                    name.sheet_id = parser().attribute<std::size_t>("localSheetId");
+                }
                 name.hidden = false;
                 if (parser().attribute_present("hidden"))
                 {

--- a/source/detail/serialization/xlsx_producer.cpp
+++ b/source/detail/serialization/xlsx_producer.cpp
@@ -447,6 +447,7 @@ void xlsx_producer::write_workbook(const relationship &rel)
         if (ws.has_auto_filter())
         {
             defined_name name;
+            name.has_sheet_id = true;
             name.sheet_id = ws.id();
             name.name = "_xlnm._FilterDatabase";
             name.hidden = true;
@@ -457,6 +458,7 @@ void xlsx_producer::write_workbook(const relationship &rel)
         if (ws.has_print_area())
         {
             defined_name name;
+            name.has_sheet_id = true;
             name.sheet_id = ws.id();
             name.name = "_xlnm.Print_Area";
             name.hidden = false;
@@ -467,6 +469,7 @@ void xlsx_producer::write_workbook(const relationship &rel)
         if (ws.has_print_titles())
         {
             defined_name name;
+            name.has_sheet_id = true;
             name.sheet_id = ws.id();
             name.name = "_xlnm.Print_Titles";
             name.hidden = false;
@@ -668,7 +671,10 @@ void xlsx_producer::write_workbook(const relationship &rel)
             {
                 write_attribute("hidden", write_bool(true));
             }
-            write_attribute("localSheetId", std::to_string(name.sheet_id - 1)); // 0-indexed for some reason
+            if (name.has_sheet_id)
+            {
+                write_attribute("localSheetId", std::to_string(name.sheet_id - 1)); // 0-indexed for some reason
+            }
             write_characters(name.value);
             write_end_element(xmlns, "definedName");
         }

--- a/source/utils/time.cpp
+++ b/source/utils/time.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/time.hpp>
 

--- a/source/utils/timedelta.cpp
+++ b/source/utils/timedelta.cpp
@@ -22,6 +22,7 @@
 // @author: see AUTHORS file
 #include <cmath>
 #include <ctime>
+#include <cstdint>
 
 #include <xlnt/utils/timedelta.hpp>
 


### PR DESCRIPTION
The existing implementation relied on implicit inclusion of cstdint which is not a given on all platforms.
Therefore, cstdint needs to be included explicitly.

Taken from the following vcpkg patch:

From 72052b959219be81605e9694df82491b12423e36 Mon Sep 17 00:00:00 2001
From: chris <x23@startracer.co.uk>
Date: Sat, 24 Feb 2024 21:56:27 +0000
Subject: [PATCH] fix uint32_t