### PR TITLE
Update number_format.cpp.  builtin_formats() is not thread-safe

### DIFF
--- a/source/styles/number_format.cpp
+++ b/source/styles/number_format.cpp
@@ -36,7 +36,7 @@ namespace {
 
 const std::unordered_map<std::size_t, xlnt::number_format> &builtin_formats()
 {
-    static std::unordered_map<std::size_t, xlnt::number_format> formats;
+    thread_local static std::unordered_map<std::size_t, xlnt::number_format> formats;
 
     if (formats.size() == 0)
     {


### PR DESCRIPTION
When generating xlnt::workbook objects concurrently in a multithreaded environment, builtin_formats() is called, and the use of static variables within builtin_formats() is not thread-safe.