### PR TITLE
Add #include <cstdint> to several places to fix compile error with Clang on Ubuntu

### DIFF
--- a/include/xlnt/cell/phonetic_run.hpp
+++ b/include/xlnt/cell/phonetic_run.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>

--- a/include/xlnt/utils/variant.hpp
+++ b/include/xlnt/utils/variant.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/source/utils/time.cpp
+++ b/source/utils/time.cpp
@@ -21,6 +21,7 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 #include <cmath>
+#include <cstdint>
 #include <ctime>
 
 #include <xlnt/utils/time.hpp>

--- a/source/utils/timedelta.cpp
+++ b/source/utils/timedelta.cpp
@@ -21,6 +21,7 @@
 // @license: http://www.opensource.org/licenses/mit-license.php
 // @author: see AUTHORS file
 #include <cmath>
+#include <cstdint>
 #include <ctime>
 
 #include <xlnt/utils/timedelta.hpp>


### PR DESCRIPTION
This resolves "error: unknown type name 'uint32_t'", tested with Clang 15/16/17/18 x86_64-pc-linux-gnu