### PR TITLE
For issue 'Build failed with GCC 14.1.1' #745, fix needed header.

### DIFF
--- a/include/xlnt/cell/phonetic_run.hpp
+++ b/include/xlnt/cell/phonetic_run.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>

--- a/include/xlnt/utils/time.hpp
+++ b/include/xlnt/utils/time.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>

--- a/include/xlnt/utils/timedelta.hpp
+++ b/include/xlnt/utils/timedelta.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <xlnt/xlnt_config.hpp>

--- a/include/xlnt/utils/variant.hpp
+++ b/include/xlnt/utils/variant.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This header had been added from GCC 4.6, so it will not fail compiling with lower and widely used versions.